### PR TITLE
fix(publish): upload AAB/APK as application/octet-stream + surface API errors

### DIFF
--- a/internal/cli/kong_bulk.go
+++ b/internal/cli/kong_bulk.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -228,8 +229,13 @@ func (cmd *BulkUploadCmd) uploadFile(ctx context.Context, client *api.Client, pk
 	case extAAB:
 		var bundle *androidpublisher.Bundle
 		err = client.DoWithRetry(ctx, func() error {
+			// Rewind: the same file handle is reused across retries, so a
+			// retried attempt must re-read from the start, not from EOF.
+			if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+				return serr
+			}
 			var uerr error
-			bundle, uerr = svc.Edits.Bundles.Upload(pkg, editID).Media(f).Context(ctx).Do()
+			bundle, uerr = svc.Edits.Bundles.Upload(pkg, editID).Media(f, googleapi.ContentType("application/octet-stream")).Context(ctx).Do()
 			return uerr
 		})
 		if err != nil {
@@ -239,8 +245,11 @@ func (cmd *BulkUploadCmd) uploadFile(ctx context.Context, client *api.Client, pk
 	case extAPK:
 		var apk *androidpublisher.Apk
 		err = client.DoWithRetry(ctx, func() error {
+			if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+				return serr
+			}
 			var uerr error
-			apk, uerr = svc.Edits.Apks.Upload(pkg, editID).Media(f).Context(ctx).Do()
+			apk, uerr = svc.Edits.Apks.Upload(pkg, editID).Media(f, googleapi.ContentType("application/octet-stream")).Context(ctx).Do()
 			return uerr
 		})
 		if err != nil {

--- a/internal/cli/kong_cli.go
+++ b/internal/cli/kong_cli.go
@@ -150,6 +150,9 @@ func RunKongCLI() int {
 	if err != nil {
 		var apiErr *errors.APIError
 		if stderrors.As(err, &apiErr) {
+			// Print the error before exiting: without this an APIError exits
+			// with only a status code and no message (a silent failure).
+			fmt.Fprintf(os.Stderr, "Error: %v\n", apiErr)
 			return apiErr.ExitCode()
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/internal/cli/kong_publish.go
+++ b/internal/cli/kong_publish.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -243,7 +244,12 @@ func (cmd *PublishUploadCmd) uploadBundle(ctx context.Context, client *api.Clien
 			}
 		}()
 
-		bundle, err := svc.Edits.Bundles.Upload(packageName, editID).Media(file).Context(ctx).Do()
+		// Force octet-stream: the Go client sniffs an AAB as application/zip,
+		// which Play's edits.bundles.upload rejects ("Media type 'application/zip'
+		// is not supported"). The API requires application/octet-stream.
+		bundle, err := svc.Edits.Bundles.Upload(packageName, editID).
+			Media(file, googleapi.ContentType("application/octet-stream")).
+			Context(ctx).Do()
 		if err != nil {
 			return err
 		}
@@ -269,7 +275,10 @@ func (cmd *PublishUploadCmd) uploadAPK(ctx context.Context, client *api.Client, 
 			}
 		}()
 
-		apk, err := svc.Edits.Apks.Upload(packageName, editID).Media(file).Context(ctx).Do()
+		// Same octet-stream requirement as bundles (an APK also sniffs as zip).
+		apk, err := svc.Edits.Apks.Upload(packageName, editID).
+			Media(file, googleapi.ContentType("application/octet-stream")).
+			Context(ctx).Do()
 		if err != nil {
 			return err
 		}
@@ -3055,7 +3064,12 @@ func (cmd *PublishDeobfuscationUploadCmd) Run(globals *Globals) error {
 	}
 	var uploadResp *androidpublisher.DeobfuscationFilesUploadResponse
 	err = client.DoWithRetry(ctx, func() error {
-		uploadResp, err = svc.Edits.Deobfuscationfiles.Upload(pkg, editID, cmd.VersionCode, cmd.Type).Media(file).Context(ctx).Do()
+		// Rewind: the same file handle is reused across retries, so a retried
+		// attempt must re-read from the start, not from EOF.
+		if _, serr := file.Seek(0, io.SeekStart); serr != nil {
+			return serr
+		}
+		uploadResp, err = svc.Edits.Deobfuscationfiles.Upload(pkg, editID, cmd.VersionCode, cmd.Type).Media(file, googleapi.ContentType("application/octet-stream")).Context(ctx).Do()
 		return err
 	})
 	client.ReleaseForUpload()
@@ -4913,7 +4927,10 @@ func (cmd *PublishInternalShareUploadCmd) Run(globals *Globals) error {
 	if ext == extAAB {
 		var resp *androidpublisher.InternalAppSharingArtifact
 		err = client.DoWithRetry(ctx, func() error {
-			resp, err = svc.Internalappsharingartifacts.Uploadbundle(pkg).Media(file).Context(ctx).Do()
+			if _, serr := file.Seek(0, io.SeekStart); serr != nil {
+				return serr
+			}
+			resp, err = svc.Internalappsharingartifacts.Uploadbundle(pkg).Media(file, googleapi.ContentType("application/octet-stream")).Context(ctx).Do()
 			return err
 		})
 		client.ReleaseForUpload()
@@ -4932,7 +4949,10 @@ func (cmd *PublishInternalShareUploadCmd) Run(globals *Globals) error {
 	} else {
 		var resp *androidpublisher.InternalAppSharingArtifact
 		err = client.DoWithRetry(ctx, func() error {
-			resp, err = svc.Internalappsharingartifacts.Uploadapk(pkg).Media(file).Context(ctx).Do()
+			if _, serr := file.Seek(0, io.SeekStart); serr != nil {
+				return serr
+			}
+			resp, err = svc.Internalappsharingartifacts.Uploadapk(pkg).Media(file, googleapi.ContentType("application/octet-stream")).Context(ctx).Do()
 			return err
 		})
 		client.ReleaseForUpload()


### PR DESCRIPTION
## Summary

Fixes binary uploads to the Play Developer API, which currently fail, plus the reason the failure was invisible.

Found by running a real `publish upload` against Play with a service account.

## Bugs

1. **Uploads rejected with HTTP 400.** Every AAB/APK/deobfuscation upload passed the file to `.Media()` without a content type, so the Go client sniffs the zip-based artifact as `application/zip`. The Play API rejects that:

   ```
   googleapi: Error 400: Media type 'application/zip' is not supported. , badRequest
   ```

2. **The error was silent.** `RunKongCLI` returned an `*errors.APIError`'s exit code *without printing the message*, so any command hitting an API error exited with only a status code and no output — which masked bug #1 (the upload just exited `1` with nothing on stdout/stderr).

3. **Retry could corrupt the upload.** Several upload paths open the file *outside* the `DoWithRetry` closure and reuse the handle, so a retried 429/5xx re-reads from EOF.

## Changes

- Set `googleapi.ContentType("application/octet-stream")` on all AAB/APK/deobfuscation uploads: `publish upload` (bundle + apk), `publish internal-share` (bundle + apk), `bulk` upload (bundle + apk), and the deobfuscation-file upload. Image/screenshot uploads are left unchanged (a PNG/JPG sniffs to a valid `image/*` type, which the API accepts).
- Print the `APIError` in `RunKongCLI` before returning its exit code (matching the generic-error branch just below it).
- `Seek(0)` at the top of each retry closure in the paths that open the file outside `DoWithRetry`. The main `publish upload` bundle/apk paths already open inside the closure and were unaffected.

## Reproduce (before this change)

```
gpd publish upload app.aab --package <pkg> --track internal --key-path <service-account.json>
```

exits `1`. With the `APIError`-print change the cause is visible as the 400 above; without it the command exits silently.

## Verification

- After the change, a real `publish upload` succeeds and the artifact appears on the track (via `publish release`), confirmed end-to-end against a live app.
- `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/cli/` all pass.

## Notes / out of scope

Two adjacent issues noticed but intentionally not touched here, happy to follow up:
- `--track` on `publish upload` is only echoed in `--dry-run`; a real upload never assigns to a track (you must use `publish release`).
- `gpd config set storeTokens ...` doesn't affect the runtime auth (the config file isn't loaded into the CLI globals; only the `--store-tokens` flag does).