### PR TITLE
feat: ASC-style parity ops (auth, validate, install, setup-gpd)

### DIFF
--- a/.github/actions/setup-gpd/action.yml
+++ b/.github/actions/setup-gpd/action.yml
@@ -1,0 +1,252 @@
+name: 'Setup gpd'
+description: 'Install the Google Play Developer CLI (gpd) binary for CI'
+author: 'dl-alexandre'
+
+branding:
+  icon: 'download'
+  color: 'green'
+
+inputs:
+  version:
+    description: 'gpd release version to install (e.g. v0.6.4, 0.6.4, or "latest")'
+    required: false
+    default: 'latest'
+  token:
+    description: 'GitHub token for API rate limits when resolving releases (defaults to github.token)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install gpd
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN_DEFAULT: ${{ github.token }}
+        GITHUB_REPOSITORY_ENV: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        DEFAULT_REPO="dl-alexandre/Google-Play-Developer-CLI"
+        # Prefer the caller's repo when it is this project (or a fork), so in-repo CI
+        # resolves releases from the same GitHub repository.
+        if [[ "${GITHUB_REPOSITORY_ENV:-}" == *"/Google-Play-Developer-CLI" ]]; then
+          REPO="${GITHUB_REPOSITORY_ENV}"
+        else
+          REPO="${DEFAULT_REPO}"
+        fi
+
+        TOKEN="${INPUT_TOKEN:-${GITHUB_TOKEN_DEFAULT:-}}"
+        AUTH_HEADER=()
+        if [ -n "${TOKEN}" ]; then
+          AUTH_HEADER=(-H "Authorization: Bearer ${TOKEN}")
+        fi
+
+        api_get() {
+          local url="$1"
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${AUTH_HEADER[@]}" \
+            "${url}"
+        }
+
+        download() {
+          local url="$1"
+          local out="$2"
+          if [ -n "${TOKEN}" ]; then
+            curl -fsSL \
+              -H "Accept: application/octet-stream" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -o "${out}" \
+              "${url}"
+          else
+            curl -fsSL -o "${out}" "${url}"
+          fi
+        }
+
+        # --- Resolve release tag ---
+        VERSION_INPUT="${INPUT_VERSION:-latest}"
+        VERSION_INPUT="${VERSION_INPUT#v}"
+
+        if [ "${VERSION_INPUT}" = "latest" ] || [ -z "${VERSION_INPUT}" ]; then
+          echo "Resolving latest release for ${REPO}..."
+          RELEASE_JSON="$(api_get "https://api.github.com/repos/${REPO}/releases/latest")"
+          TAG="$(printf '%s' "${RELEASE_JSON}" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+        else
+          TAG="v${VERSION_INPUT}"
+          echo "Resolving release ${TAG} for ${REPO}..."
+          # Validate the tag exists (falls back to tag endpoint if no formal release).
+          if ! RELEASE_JSON="$(api_get "https://api.github.com/repos/${REPO}/releases/tags/${TAG}" 2>/dev/null)"; then
+            if api_get "https://api.github.com/repos/${REPO}/git/refs/tags/${TAG}" >/dev/null 2>&1; then
+              RELEASE_JSON=""
+            else
+              echo "::error::Release or tag '${TAG}' not found in ${REPO}"
+              exit 1
+            fi
+          fi
+        fi
+
+        if [ -z "${TAG:-}" ]; then
+          echo "::error::Could not resolve a release tag for ${REPO}"
+          exit 1
+        fi
+        VERSION="${TAG#v}"
+        echo "Installing gpd ${TAG} from ${REPO}"
+
+        # --- Map runner OS / ARCH (install.sh + goreleaser naming) ---
+        UNAME_S="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        UNAME_M="$(uname -m)"
+
+        case "${UNAME_S}" in
+          linux)  OS="linux" ;;
+          darwin) OS="darwin" ;;
+          mingw*|msys*|cygwin*) OS="windows" ;;
+          *)
+            echo "::error::Unsupported OS: ${UNAME_S}"
+            exit 1
+            ;;
+        esac
+
+        case "${UNAME_M}" in
+          x86_64|amd64)
+            ARCH_INSTALL="x86_64"
+            ARCH_GO="amd64"
+            ;;
+          arm64|aarch64)
+            ARCH_INSTALL="arm64"
+            ARCH_GO="arm64"
+            ;;
+          *)
+            echo "::error::Unsupported architecture: ${UNAME_M}"
+            exit 1
+            ;;
+        esac
+
+        if [ "${OS}" = "windows" ]; then
+          EXT_INSTALL="zip"
+          EXT_GO="zip"
+        else
+          EXT_INSTALL="tar.gz"
+          EXT_GO="tar.gz"
+        fi
+
+        # Prefer install.sh naming, then current GoReleaser asset names.
+        CANDIDATES=(
+          "gpd_${VERSION}_${OS}_${ARCH_INSTALL}.${EXT_INSTALL}"
+          "gpd-${OS}-${ARCH_GO}.${EXT_GO}"
+          "gpd_${VERSION}_${OS}_${ARCH_GO}.${EXT_INSTALL}"
+        )
+
+        BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+        TMP_DIR="$(mktemp -d)"
+        trap 'rm -rf "${TMP_DIR}"' EXIT
+
+        ASSET_NAME=""
+        ASSET_PATH=""
+        for name in "${CANDIDATES[@]}"; do
+          echo "Trying asset: ${name}"
+          if download "${BASE_URL}/${name}" "${TMP_DIR}/${name}" 2>/dev/null; then
+            ASSET_NAME="${name}"
+            ASSET_PATH="${TMP_DIR}/${name}"
+            break
+          fi
+        done
+
+        if [ -z "${ASSET_PATH}" ] || [ ! -f "${ASSET_PATH}" ]; then
+          echo "::error::Could not download a gpd asset for ${OS}/${ARCH_GO} (tag ${TAG}). Tried: ${CANDIDATES[*]}"
+          exit 1
+        fi
+        echo "Downloaded ${ASSET_NAME}"
+
+        # --- Checksums (prefer gpd_*_checksums.txt, then checksums.txt) ---
+        CHECKSUMS_PATH="${TMP_DIR}/checksums.txt"
+        CHECKSUMS_OK=0
+        for cname in "gpd_${VERSION}_checksums.txt" "checksums.txt" "gpd_${TAG}_checksums.txt"; do
+          if download "${BASE_URL}/${cname}" "${CHECKSUMS_PATH}" 2>/dev/null; then
+            echo "Using checksums file: ${cname}"
+            CHECKSUMS_OK=1
+            break
+          fi
+        done
+
+        if [ "${CHECKSUMS_OK}" -ne 1 ]; then
+          echo "::warning::No checksums.txt / gpd_*_checksums.txt found for ${TAG}; installing WITHOUT checksum verification."
+        else
+          expected="$(awk -v asset="${ASSET_NAME}" '
+            $2 == asset || $2 == ("*" asset) { print $1; exit }
+          ' "${CHECKSUMS_PATH}")"
+          if [ -z "${expected}" ]; then
+            echo "::warning::Asset ${ASSET_NAME} not listed in checksums file; installing WITHOUT checksum verification."
+          else
+            if command -v shasum >/dev/null 2>&1; then
+              actual="$(shasum -a 256 "${ASSET_PATH}" | awk '{print $1}')"
+            elif command -v sha256sum >/dev/null 2>&1; then
+              actual="$(sha256sum "${ASSET_PATH}" | awk '{print $1}')"
+            else
+              echo "::warning::No shasum/sha256sum available; installing WITHOUT checksum verification."
+              actual=""
+            fi
+
+            if [ -n "${actual}" ]; then
+              if [ "${expected}" != "${actual}" ]; then
+                # GoReleaser may use blake3; if lengths differ, warn instead of hard-failing.
+                if [ "${#expected}" -ne "${#actual}" ]; then
+                  echo "::warning::Checksum algorithm mismatch for ${ASSET_NAME} (expected digest length ${#expected}, sha256 length ${#actual}); skipping strict verify."
+                else
+                  echo "::error::Checksum verification failed for ${ASSET_NAME}"
+                  echo "  expected: ${expected}"
+                  echo "  actual:   ${actual}"
+                  exit 1
+                fi
+              else
+                echo "Checksum verified for ${ASSET_NAME}"
+              fi
+            fi
+          fi
+        fi
+
+        # --- Extract / install ---
+        INSTALL_DIR="${RUNNER_TEMP:-/tmp}/gpd-bin"
+        mkdir -p "${INSTALL_DIR}"
+
+        case "${ASSET_NAME}" in
+          *.tar.gz|*.tgz)
+            tar -xzf "${ASSET_PATH}" -C "${TMP_DIR}"
+            ;;
+          *.zip)
+            if command -v unzip >/dev/null 2>&1; then
+              unzip -qo "${ASSET_PATH}" -d "${TMP_DIR}"
+            else
+              echo "::error::unzip is required to extract Windows zip assets"
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::Unknown archive format: ${ASSET_NAME}"
+            exit 1
+            ;;
+        esac
+
+        BIN_SRC="$(find "${TMP_DIR}" -type f \( -name 'gpd' -o -name 'gpd.exe' \) | head -n1)"
+        if [ -z "${BIN_SRC}" ] || [ ! -f "${BIN_SRC}" ]; then
+          echo "::error::gpd binary not found after extracting ${ASSET_NAME}"
+          ls -la "${TMP_DIR}" || true
+          exit 1
+        fi
+
+        BIN_NAME="gpd"
+        if [[ "${BIN_SRC}" == *.exe ]]; then
+          BIN_NAME="gpd.exe"
+        fi
+
+        mv "${BIN_SRC}" "${INSTALL_DIR}/${BIN_NAME}"
+        chmod +x "${INSTALL_DIR}/${BIN_NAME}"
+
+        echo "${INSTALL_DIR}" >> "${GITHUB_PATH}"
+        export PATH="${INSTALL_DIR}:${PATH}"
+
+        echo "gpd installed to ${INSTALL_DIR}/${BIN_NAME}"
+        "${INSTALL_DIR}/${BIN_NAME}" version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
         if: steps.published.outputs.skip != 'true'
         run: go test ./...
 
+      # Publishes platform archives (gpd_<ver>_<os>_<arch>.tar.gz|zip),
+      # gpd_<ver>_checksums.txt (SHA-256 for install.sh), Homebrew, and Scoop.
       - name: Run GoReleaser
         if: steps.published.outputs.skip != 'true'
         uses: goreleaser/goreleaser-action@v7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,11 +7,13 @@ before:
   hooks:
     - go mod tidy
     - go mod verify
-    - go test ./...
+    # Prefer unit tags for speed/stability in release builds (integration/workflow tests can flake).
+    - go test -tags=unit ./...
 
 builds:
   - id: gpd
-    main: ./...
+    main: ./cmd/gpd
+    binary: gpd
     env:
       - CGO_ENABLED=0
     goos:
@@ -23,15 +25,18 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.gitCommit={{.Commit}}
-      - -X main.buildTime={{.Date}}
+      - -X github.com/dl-alexandre/Google-Play-Developer-CLI/pkg/version.Version={{.Version}}
+      - -X github.com/dl-alexandre/Google-Play-Developer-CLI/pkg/version.GitCommit={{.Commit}}
+      - -X github.com/dl-alexandre/Google-Play-Developer-CLI/pkg/version.BuildTime={{.Date}}
     flags:
       - -trimpath
 
 archives:
   - id: gpd
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    # Must match install.sh FILENAME: gpd_${VERSION}_${OS}_${ARCH}.tar.gz
+    # (OS: darwin/linux/windows; ARCH: x86_64 for amd64, else arm64/…)
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -41,9 +46,11 @@ archives:
       - README.md
       - CHANGELOG.md
 
+# install.sh verifies SHA-256 lines in shasum format: "<hash>  <filename>"
+# Prefers gpd_${VERSION}_checksums.txt, falls back to checksums.txt.
 checksum:
-  name_template: "checksums.txt"
-  algorithm: blake3
+  name_template: "gpd_{{ .Version }}_checksums.txt"
+  algorithm: sha256
 
 changelog:
   sort: asc
@@ -75,9 +82,11 @@ release:
     Download the appropriate binary for your platform from the assets below.
     
     ### Verification
-    Verify checksums:
+    Each release publishes `gpd_{{ .Version }}_checksums.txt` (SHA-256, shasum format).
+    The install script verifies this automatically; to verify manually:
     ```bash
-    b3sum -c checksums.txt
+    shasum -a 256 -c gpd_{{ .Version }}_checksums.txt
+    # or: sha256sum -c gpd_{{ .Version }}_checksums.txt
     ```
 
 brews:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,10 +141,19 @@ git push origin v0.1.0
 ```
 
 GoReleaser handles:
-- Cross-platform builds
+- Cross-platform builds (archives named `gpd_<version>_<os>_<arch>.tar.gz` / `.zip`)
+- SHA-256 checksums (`gpd_<version>_checksums.txt`) for `install.sh` verification
 - GitHub releases
 - Homebrew formula updates
-- Docker image publishing
+- Scoop bucket updates
+
+`install.sh` downloads those archives and verifies SHA-256 against the checksums
+asset (override with `GPD_INSTALL_INSECURE=1` only when you must skip verification).
+Smoke-test checksum/install logic without a real release:
+
+```bash
+make test-install-checksum
+```
 
 ## Questions?
 

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ PLATFORMS = linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
 
 .PHONY: all build build-optimized build-small build-optimized-all build-all clean test deps tidy lint install help format install-hooks \
 	benchmark benchmark-compare benchmark-regression benchmark-baseline \
-	test-unit test-integration test-e2e test-coverage-threshold test-flaky security check vet \
-	apidrift apidrift-check apidrift-json apidrift-markdown apidrift-build apidrift-verbose apidrift-multi
+	test-unit test-integration test-e2e test-coverage-threshold test-flaky test-install-checksum security check vet \
+	apidrift apidrift-check apidrift-json apidrift-markdown apidrift-build apidrift-verbose apidrift-multi \
+	generate-command-docs check-docs
 
 # Default target
 all: deps build
@@ -89,9 +90,17 @@ build-optimized-all:
 	@echo "Running full optimization build..."
 	@bash ./scripts/build-optimized.sh all
 
+# Generate docs/COMMANDS.md from live gpd help
+generate-command-docs: build
+	@bash ./scripts/generate-command-docs.sh
+
+# Fail if docs/COMMANDS.md drifts from live help
+check-docs: build
+	@bash ./scripts/check-command-docs.sh
+
 # Run all checks (format, vet, lint, test)
 .PHONY: check
-check: format vet lint test
+check: format vet lint test check-docs
 	@echo "✓ All checks passed"
 
 # Run go vet
@@ -126,6 +135,11 @@ test-all:
 test-unit:
 	@echo "Running unit tests..."
 	@bash -o pipefail -c '$(GOTEST) -v -race -cover -tags=unit -count=1 ./... 2>&1 | sed "/malformed LC_DYSYMTAB/d"'
+
+# Smoke-test install.sh checksum verification + GoReleaser naming alignment
+test-install-checksum:
+	@echo "Running install checksum smoke tests..."
+	@bash ./scripts/test-install-checksum.sh "$(CURDIR)/.tmp/install-checksum"
 
 # Run only integration tests
 test-integration:
@@ -306,6 +320,7 @@ help:
 	@echo ""
 	@echo "Test & Quality:"
 	@echo "  test              - Run tests"
+	@echo "  test-install-checksum - Smoke-test install.sh checksum verification"
 	@echo "  test-coverage     - Run tests with coverage report"
 	@echo "  lint              - Run linter"
 	@echo "  benchmark         - Run all benchmarks"

--- a/README.md
+++ b/README.md
@@ -120,12 +120,21 @@ gpd publish upload myapp.aab --package com.example.app --track internal --json
 gpd is purpose-built for programmatic access by AI agents and automation:
 
 ```bash
-# Get the AI agent quickstart guide
-gpd help agent
-
 # Example: Query reviews and get structured JSON for processing
 gpd reviews list --package com.example.app --min-rating 1 --output json --pretty
 ```
+
+### Agent skills pack
+
+Installable ASC-style skills live under [`skills/`](skills/README.md). Point your agent at the skill folders (or copy/symlink them into your agent skills root):
+
+| Skill | Path |
+| --- | --- |
+| Auth (service account, profiles, doctor/check) | [`skills/gpd-auth`](skills/gpd-auth/SKILL.md) |
+| Release (validate, publish play, rollout) | [`skills/gpd-release`](skills/gpd-release/SKILL.md) |
+| Reviews & vitals | [`skills/gpd-reviews-vitals`](skills/gpd-reviews-vitals/SKILL.md) |
+
+See [`skills/README.md`](skills/README.md) for install notes. Prefer live `gpd <cmd> --help` over inventing flags.
 
 **Key features for automation:**
 
@@ -193,6 +202,27 @@ brew install gpd
 curl -fsSL https://raw.githubusercontent.com/dl-alexandre/Google-Play-Developer-CLI/main/install.sh | bash
 ```
 
+The install script downloads the release archive matching your OS/arch
+(`gpd_<version>_<os>_<arch>.tar.gz`) and **requires SHA-256 verification** against
+the release checksums file (`gpd_<version>_checksums.txt`, or `checksums.txt`).
+If checksums cannot be downloaded or verified, install aborts unless you
+explicitly opt out:
+
+```bash
+# Only if you understand the risk (e.g. air-gapped debug); not recommended
+GPD_INSTALL_INSECURE=1 curl -fsSL https://raw.githubusercontent.com/dl-alexandre/Google-Play-Developer-CLI/main/install.sh | bash
+```
+
+### GitHub Actions (`setup-gpd`)
+
+```yaml
+- uses: dl-alexandre/Google-Play-Developer-CLI/.github/actions/setup-gpd@main
+  with:
+    version: v0.6.4   # pin for CI; use latest only for throwaway jobs
+```
+
+See [CI/CD integration](docs/examples/ci-cd-integration.md#install-gpd-in-ci-setup-gpd) for full examples.
+
 ### Go Install
 
 ```bash
@@ -251,10 +281,10 @@ gpd config doctor
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--package` | App package name | - |
-| `--output` | Output format: json, table, markdown, csv (analytics/vitals only) | json |
+| `--output` | Output format: json, table, markdown, csv, excel | table on TTY, json in pipes/CI (`GPD_DEFAULT_OUTPUT` overrides) |
 | `--pretty` | Pretty print JSON output | false |
 | `--timeout` | Network timeout | 30s |
-| `--key` | Service account key file path | - |
+| `--key-path` | Service account key file path | - |
 | `--quiet` | Suppress stderr except errors | false |
 | `--verbose` | Verbose output | false |
 | `--profile` | Authentication profile name | - |
@@ -267,18 +297,22 @@ gpd config doctor
 #### `gpd auth` - Authentication
 
 ```bash
-gpd auth login              # OAuth device login (uses GPD_CLIENT_ID)
-gpd auth init               # Alias for auth login
-gpd auth switch <profile>   # Switch active profile
-gpd auth list               # List stored profiles
-gpd auth status              # Check authentication status
-gpd auth check --package ... # Validate permissions
-gpd auth logout              # Clear stored credentials
-gpd auth diagnose            # Detailed auth diagnostics
-gpd auth doctor              # Diagnose authentication setup
+gpd auth login [profile] --key-path sa.json   # Service account login (CI-friendly)
+gpd auth init [profile]                       # Alias for auth login
+gpd auth switch <profile>                     # Switch + persist active profile
+gpd auth list                                 # List stored profiles
+gpd auth status                               # Check authentication status
+gpd auth check --package com.example.app      # Validate package API access
+gpd auth logout                               # Clear session credentials
+gpd auth doctor --refresh-check               # Sectioned auth diagnostics
+gpd auth diagnose --refresh-check             # Alias for auth doctor
 ```
 
+Profile resolution: `--profile` → `GPD_AUTH_PROFILE` → config `activeProfile` → `default`.
+
 If your OAuth consent screen is in testing mode, refresh tokens can expire after 7 days and Google enforces a 100 refresh-token issuance cap per OAuth client. If you encounter repeated `invalid_grant` refresh failures, re-authenticate and revoke unused tokens in Google Cloud Console, or move the app to production.
+
+More detail: [docs/auth-parity-guide.md](docs/auth-parity-guide.md).
 
 #### `gpd config` - Configuration
 
@@ -638,7 +672,19 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 
 ## App Store Connect CLI Parity
 
-See the parity matrix in [docs/asc-parity.md](docs/asc-parity.md).
+Coming from [App Store Connect CLI](https://github.com/rorkai/App-Store-Connect-CLI)? Start here:
+
+- [docs/asc-parity.md](docs/asc-parity.md) — feature parity matrix (verified against live help)
+- [docs/auth-parity-guide.md](docs/auth-parity-guide.md) — auth migration + profiles
+- [docs/asc-workflow-mapping.md](docs/asc-workflow-mapping.md) — release/build/metadata workflows
+- [docs/COMMANDS.md](docs/COMMANDS.md) — generated command taxonomy (`make generate-command-docs`)
+
+High-level Play ship ergonomics:
+
+```bash
+gpd validate --package com.example.app --file ./app.aab --dry-run
+gpd publish play ./app.aab --package com.example.app --track internal --dry-run
+```
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,688 @@
+# Command Reference Guide
+
+This file is generated from live CLI help output.
+For authoritative command behavior, also use:
+
+```bash
+gpd --help
+gpd <command> --help
+gpd <command> <subcommand> --help
+```
+
+To regenerate:
+
+```bash
+make generate-command-docs
+```
+
+Generated: 2026-07-17T05:31:40Z
+
+## Global help
+
+```
+Usage: gpd <command> [flags]
+
+Google Play Developer CLI - A fast, lightweight command-line interface for the
+Google Play Developer Console.
+
+Flags:
+  -h, --help                   Show context-sensitive help.
+  -p, --package=STRING         App package name
+      --output="json"          Output format: json, table, markdown, csv,
+                               excel (default: table on TTY, json in pipes/CI;
+                               override with GPD_DEFAULT_OUTPUT)
+      --pretty                 Pretty print JSON output
+      --timeout=30s            Network timeout
+      --store-tokens="auto"    Token storage: auto, never, secure
+      --fields=STRING          JSON field projection (comma-separated paths)
+      --quiet                  Suppress non-error output
+  -v, --verbose                Enable verbose logging
+      --key-path=STRING        Path to service account key file
+      --profile=STRING         Configuration profile to use
+      --cache-dir=STRING       Cache directory for temporary data
+                               ($GPD_CACHE_DIR)
+
+Commands:
+  auth status                      Check authentication status
+  auth login                       Authenticate with Google Play
+  auth init                        Initialize auth for a profile (alias of
+                                   login)
+  auth logout                      Sign out and clear stored credentials for a
+                                   profile
+  auth delete                      Delete a stored authentication profile
+  auth list                        List stored authentication profiles
+  auth switch                      Switch the active authentication profile
+  auth check                       Validate package permissions for current
+                                   credentials
+  auth doctor                      Diagnose authentication setup
+  auth diagnose                    Detailed auth diagnostics (alias of doctor)
+  config init                      Initialize project configuration
+  config doctor                    Diagnose configuration and credential issues
+  config path                      Show configuration paths
+  config get                       Get configuration value
+  config set                       Set configuration value
+  config print                     Print current configuration
+  config export                    Export configuration to file
+  config import                    Import configuration from file
+  config completion                Generate shell completion script
+  publish play                     High-level upload→track→status publish job
+                                   (ASC publish analogue)
+  publish upload                   Upload APK or AAB
+  publish release                  Create or update a release
+  publish rollout                  Update rollout percentage
+  publish promote                  Promote a release between tracks
+  publish halt                     Halt a production rollout
+  publish rollback                 Rollback to a previous version
+  publish status                   Get track status
+  publish tracks                   List all tracks
+  publish capabilities             List publishing capabilities
+  publish listing update           Update store listing
+  publish listing get              Get store listing
+  publish listing delete           Delete store listing
+  publish details get              Get app details
+  publish details update           Update app details
+  publish details patch            Patch app details
+  publish images upload            Upload an image
+  publish images list              List images
+  publish images delete            Delete an image
+  publish images delete-all        Delete all images for type
+  publish assets upload            Upload assets from directory
+  publish assets spec              Output asset validation matrix
+  publish deobfuscation upload     Upload deobfuscation file
+  publish testers add              Add tester groups
+  publish testers remove           Remove tester groups
+  publish testers list             List tester groups
+  publish testers get              Get tester groups for a track
+  publish builds list              List uploaded builds
+  publish builds get               Get build details
+  publish builds expire            Expire a build from tracks
+  publish builds expire-all        Expire all builds from tracks
+  publish beta-groups list         List beta groups
+  publish beta-groups get          Get beta group details
+  publish beta-groups create       Create beta group
+  publish beta-groups update       Update beta group testers
+  publish beta-groups delete       Delete beta group
+  publish beta-groups add-testers
+                                   Add tester Google Groups to a beta group
+  publish beta-groups remove-testers
+                                   Remove tester Google Groups from a beta group
+  publish internal-share upload    Upload artifact for internal sharing
+  reviews list                     List user reviews
+  reviews get                      Get a review by ID
+  reviews reply                    Reply to a review
+  reviews response-get             Get response for a review
+  reviews response-delete          Delete response for a review
+  vitals crashes                   Query crash rate data
+  vitals anrs                      Query ANR rate data
+  vitals errors issues             Search error issues
+  vitals errors reports            Search error reports
+  vitals errors counts get         Get error count metrics
+  vitals errors counts query       Query error counts over time
+  vitals metrics excessive-wakeups
+                                   Query excessive wakeups data
+  vitals metrics slow-rendering    Query slow rendering data
+  vitals metrics slow-start        Query slow start data
+  vitals metrics stuck-wakelocks
+                                   Query stuck wakelocks data
+  vitals anomalies list            List anomalies
+  vitals query                     Query vitals metrics
+  vitals capabilities              List available vitals metrics
+  monitor watch                    Continuous vitals monitoring with threshold
+                                   alerts
+  monitor anomalies                Detect statistical anomalies in vitals
+                                   metrics
+  monitor dashboard                Generate monitoring dashboard data
+  monitor report                   Generate scheduled monitoring reports
+  monitor webhooks list            List configured webhooks (simulated)
+  analytics query                  Query analytics data
+  analytics capabilities           List analytics capabilities
+  purchases products acknowledge
+                                   Acknowledge a product purchase
+  purchases products consume       Consume a product purchase
+  purchases subscriptions acknowledge
+                                   Acknowledge a subscription purchase
+  purchases subscriptions cancel
+                                   Cancel a subscription
+  purchases subscriptions defer    Defer a subscription renewal
+  purchases subscriptions refund
+                                   Refund a subscription
+  purchases subscriptions revoke
+                                   Revoke a subscription
+  purchases verify                 Verify purchase
+  purchases voided list            List voided purchases
+  purchases capabilities           List purchase verification capabilities
+  monetization products list       List in-app products
+  monetization products get        Get an in-app product
+  monetization products create     Create an in-app product
+  monetization products update     Update an in-app product
+  monetization products delete     Delete an in-app product
+  monetization subscriptions list
+                                   List subscription products
+  monetization subscriptions get
+                                   Get a subscription product
+  monetization subscriptions create
+                                   Create a subscription
+  monetization subscriptions update
+                                   Update a subscription
+  monetization subscriptions patch
+                                   Patch a subscription
+  monetization subscriptions delete
+                                   Delete a subscription
+  monetization subscriptions archive
+                                   Archive a subscription
+  monetization subscriptions batch-get
+                                   Batch get subscriptions
+  monetization subscriptions batch-update
+                                   Batch update subscriptions
+  monetization one-time-products list
+                                   List one-time products
+  monetization one-time-products get
+                                   Get a one-time product
+  monetization one-time-products create
+                                   Create a one-time product
+  monetization one-time-products update
+                                   Update a one-time product
+  monetization one-time-products delete
+                                   Delete a one-time product
+  monetization one-time-products batch-get
+                                   Batch get one-time products
+  monetization one-time-products batch-update
+                                   Batch update one-time products
+  monetization base-plans activate
+                                   Activate a base plan
+  monetization base-plans deactivate
+                                   Deactivate a base plan
+  monetization base-plans delete
+                                   Delete a base plan
+  monetization base-plans migrate-prices
+                                   Migrate base plan prices
+  monetization base-plans batch-migrate
+                                   Batch migrate base plan prices
+  monetization base-plans batch-update-states
+                                   Batch update base plan states
+  monetization offers create       Create an offer
+  monetization offers get          Get an offer
+  monetization offers list         List offers
+  monetization offers delete       Delete an offer
+  monetization offers activate     Activate an offer
+  monetization offers deactivate
+                                   Deactivate an offer
+  monetization offers batch-get    Batch get offers
+  monetization offers batch-update
+                                   Batch update offers
+  monetization offers batch-update-states
+                                   Batch update offer states
+  monetization capabilities        List monetization capabilities
+  permissions users add            Add a user
+  permissions users remove         Remove a user
+  permissions users list           List users
+  permissions grants add           Add a grant
+  permissions grants remove        Remove a grant
+  permissions grants list          List grants
+  permissions list                 List permissions
+  recovery list                    List recovery actions
+  recovery create                  Create recovery action
+  recovery deploy                  Deploy recovery
+  recovery cancel                  Cancel recovery
+  apps list                        List apps in the developer account
+  apps get                         Get app details
+  games achievements reset         Reset achievements
+  games scores reset               Reset scores on a leaderboard
+  games events reset               Reset game events
+  games players hide               Hide a player
+  games players unhide             Unhide a player
+  games capabilities               List Games management capabilities
+  integrity decode                 Decode integrity token
+  migrate                          Migration commands
+  custom-app (customapp)           Custom app publishing
+  generated-apks list              List generated APK variants for a bundle
+  generated-apks download          Download a generated APK
+  system-apks variants list        List system APK variants for a version code
+  system-apks variants get         Get a specific system APK variant
+  system-apks variants create      Create a system APK variant for a device spec
+  system-apks variants download    Download a system APK variant
+  grouping                         App access grouping
+  version                          Show version information
+  check-update                     Check for available updates
+  completion                       Generate shell completion scripts
+  maintenance drift                Detect API drift between discovery and client
+                                   library
+  maintenance multi-drift          Monitor drift across multiple Google APIs
+  maintenance health               Check system health and dependencies
+  maintenance update-check         Check for CLI updates
+  bulk upload                      Upload multiple APKs/AABs in parallel
+  bulk listings                    Update store listings across multiple locales
+  bulk images                      Batch upload images for multiple types
+  bulk tracks                      Update multiple tracks at once
+  compare vitals                   Compare vitals metrics across multiple apps
+  compare reviews                  Compare review metrics across apps
+  compare releases                 Compare release history across apps
+  compare subscriptions            Compare subscription metrics
+  release-mgmt calendar            Show upcoming and past releases
+  release-mgmt conflicts           Detect version code conflicts
+  release-mgmt strategy            Get rollback/roll-forward recommendations
+  release-mgmt history             Show detailed release history
+  release-mgmt notes               Manage release notes across locales
+  testing prelaunch                Trigger or check pre-launch report
+  testing device-lab               Run tests on Firebase Test Lab
+  testing screenshots              Capture screenshots across devices
+  testing validate                 Comprehensive app validation
+  testing compatibility            Check device compatibility
+  automation release-notes         Generate release notes from git history or
+                                   PRs
+  automation rollout               Automated staged rollout with health checks
+  automation promote               Smart promote with optional verification
+  automation validate              Comprehensive pre-release validation
+  automation monitor               Monitor release health after rollout
+  workflow run                     Execute a workflow from a JSON file
+  workflow list                    List available workflows and run history
+  workflow show                    Show workflow definition and details
+  workflow status                  Show status of a workflow run
+  workflow init                    Create a new workflow from template
+  workflow logs                    Show logs from a workflow run step
+  workflow validate                Validate workflow file for errors
+  validate                         Submission readiness / pre-publish validation
+                                   report
+  extension install                Install an extension
+  extension list                   List installed extensions
+  extension remove                 Remove an extension
+  extension upgrade                Upgrade an extension
+  extension exec                   Execute an extension explicitly
+
+Run "gpd <command> --help" for more information on a command.
+
+Extension Commands:
+  gpd test-ext  Extension command
+```
+
+## Auth
+
+```
+Usage: gpd auth <command> [flags]
+
+Authentication commands
+
+Flags:
+  -h, --help                   Show context-sensitive help.
+  -p, --package=STRING         App package name
+      --output="json"          Output format: json, table, markdown, csv,
+                               excel (default: table on TTY, json in pipes/CI;
+                               override with GPD_DEFAULT_OUTPUT)
+      --pretty                 Pretty print JSON output
+      --timeout=30s            Network timeout
+      --store-tokens="auto"    Token storage: auto, never, secure
+      --fields=STRING          JSON field projection (comma-separated paths)
+      --quiet                  Suppress non-error output
+  -v, --verbose                Enable verbose logging
+      --key-path=STRING        Path to service account key file
+      --profile=STRING         Configuration profile to use
+      --cache-dir=STRING       Cache directory for temporary data
+                               ($GPD_CACHE_DIR)
+
+Commands:
+  auth status      Check authentication status
+  auth login       Authenticate with Google Play
+  auth init        Initialize auth for a profile (alias of login)
+  auth logout      Sign out and clear stored credentials for a profile
+  auth delete      Delete a stored authentication profile
+  auth list        List stored authentication profiles
+  auth switch      Switch the active authentication profile
+  auth check       Validate package permissions for current credentials
+  auth doctor      Diagnose authentication setup
+  auth diagnose    Detailed auth diagnostics (alias of doctor)
+
+Extension Commands:
+  gpd test-ext  Extension command
+```
+
+## Publish
+
+```
+Usage: gpd publish <command> [flags]
+
+Publishing commands
+
+Flags:
+  -h, --help                   Show context-sensitive help.
+  -p, --package=STRING         App package name
+      --output="json"          Output format: json, table, markdown, csv,
+                               excel (default: table on TTY, json in pipes/CI;
+                               override with GPD_DEFAULT_OUTPUT)
+      --pretty                 Pretty print JSON output
+      --timeout=30s            Network timeout
+      --store-tokens="auto"    Token storage: auto, never, secure
+      --fields=STRING          JSON field projection (comma-separated paths)
+      --quiet                  Suppress non-error output
+  -v, --verbose                Enable verbose logging
+      --key-path=STRING        Path to service account key file
+      --profile=STRING         Configuration profile to use
+      --cache-dir=STRING       Cache directory for temporary data
+                               ($GPD_CACHE_DIR)
+
+Commands:
+  publish play                     High-level upload→track→status publish job
+                                   (ASC publish analogue)
+  publish upload                   Upload APK or AAB
+  publish release                  Create or update a release
+  publish rollout                  Update rollout percentage
+  publish promote                  Promote a release between tracks
+  publish halt                     Halt a production rollout
+  publish rollback                 Rollback to a previous version
+  publish status                   Get track status
+  publish tracks                   List all tracks
+  publish capabilities             List publishing capabilities
+  publish listing update           Update store listing
+  publish listing get              Get store listing
+  publish listing delete           Delete store listing
+  publish details get              Get app details
+  publish details update           Update app details
+  publish details patch            Patch app details
+  publish images upload            Upload an image
+  publish images list              List images
+  publish images delete            Delete an image
+  publish images delete-all        Delete all images for type
+  publish assets upload            Upload assets from directory
+  publish assets spec              Output asset validation matrix
+  publish deobfuscation upload     Upload deobfuscation file
+  publish testers add              Add tester groups
+  publish testers remove           Remove tester groups
+  publish testers list             List tester groups
+  publish testers get              Get tester groups for a track
+  publish builds list              List uploaded builds
+  publish builds get               Get build details
+  publish builds expire            Expire a build from tracks
+  publish builds expire-all        Expire all builds from tracks
+  publish beta-groups list         List beta groups
+  publish beta-groups get          Get beta group details
+  publish beta-groups create       Create beta group
+  publish beta-groups update       Update beta group testers
+  publish beta-groups delete       Delete beta group
+  publish beta-groups add-testers
+                                   Add tester Google Groups to a beta group
+  publish beta-groups remove-testers
+                                   Remove tester Google Groups from a beta group
+  publish internal-share upload    Upload artifact for internal sharing
+
+Extension Commands:
+  gpd test-ext  Extension command
+```
+
+## Validate
+
+```
+Usage: gpd validate [flags]
+
+Submission readiness / pre-publish validation report
+
+Flags:
+  -h, --help                   Show context-sensitive help.
+  -p, --package=STRING         App package name
+      --output="json"          Output format: json, table, markdown, csv,
+                               excel (default: table on TTY, json in pipes/CI;
+                               override with GPD_DEFAULT_OUTPUT)
+      --pretty                 Pretty print JSON output
+      --timeout=30s            Network timeout
+      --store-tokens="auto"    Token storage: auto, never, secure
+      --fields=STRING          JSON field projection (comma-separated paths)
+      --quiet                  Suppress non-error output
+  -v, --verbose                Enable verbose logging
+      --key-path=STRING        Path to service account key file
+      --profile=STRING         Configuration profile to use
+      --cache-dir=STRING       Cache directory for temporary data
+                               ($GPD_CACHE_DIR)
+
+      --track="internal"       Target track for the readiness plan
+      --file=STRING            Optional APK/AAB path to validate locally
+      --strict                 Treat warnings as failures
+      --dry-run                Plan checks without network side effects (default
+                               true)
+      --network                Opt-in network probes: package access,
+                               track list, listing (requires --package and
+                               credentials)
+
+Extension Commands:
+  gpd test-ext  Extension command
+```
+
+## Workflow
+
+```
+Usage: gpd workflow <command> [flags]
+
+Declarative workflow execution
+
+Flags:
+  -h, --help                   Show context-sensitive help.
+  -p, --package=STRING         App package name
+      --output="json"          Output format: json, table, markdown, csv,
+                               excel (default: table on TTY, json in pipes/CI;
+                               override with GPD_DEFAULT_OUTPUT)
+      --pretty                 Pretty print JSON output
+      --timeout=30s            Network timeout
+      --store-tokens="auto"    Token storage: auto, never, secure
+      --fields=STRING          JSON field projection (comma-separated paths)
+      --quiet                  Suppress non-error output
+  -v, --verbose                Enable verbose logging
+      --key-path=STRING        Path to service account key file
+      --profile=STRING         Configuration profile to use
+      --cache-dir=STRING       Cache directory for temporary data
+                               ($GPD_CACHE_DIR)
+
+Commands:
+  workflow run         Execute a workflow from a JSON file
+  workflow list        List available workflows and run history
+  workflow show        Show workflow definition and details
+  workflow status      Show status of a workflow run
+  workflow init        Create a new workflow from template
+  workflow logs        Show logs from a workflow run step
+  workflow validate    Validate workflow file for errors
+
+Extension Commands:
+  gpd test-ext  Extension command
+```
+
+## Command families (top-level)
+
+- `auth`
+- `auth`
+- `auth`
+- `auth`
+- `auth`
+- `auth`
+- `auth`
+- `auth`
+- `auth`
+- `auth`
+- `config`
+- `config`
+- `config`
+- `config`
+- `config`
+- `config`
+- `config`
+- `config`
+- `config`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `publish`
+- `reviews`
+- `reviews`
+- `reviews`
+- `reviews`
+- `reviews`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `vitals`
+- `monitor`
+- `monitor`
+- `monitor`
+- `monitor`
+- `monitor`
+- `analytics`
+- `analytics`
+- `purchases`
+- `purchases`
+- `purchases`
+- `purchases`
+- `purchases`
+- `purchases`
+- `purchases`
+- `purchases`
+- `purchases`
+- `purchases`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `monetization`
+- `permissions`
+- `permissions`
+- `permissions`
+- `permissions`
+- `permissions`
+- `permissions`
+- `permissions`
+- `recovery`
+- `recovery`
+- `recovery`
+- `recovery`
+- `apps`
+- `apps`
+- `games`
+- `games`
+- `games`
+- `games`
+- `games`
+- `games`
+- `integrity`
+- `migrate`
+- `custom-app`
+- `generated-apks`
+- `generated-apks`
+- `system-apks`
+- `system-apks`
+- `system-apks`
+- `system-apks`
+- `grouping`
+- `version`
+- `check-update`
+- `completion`
+- `maintenance`
+- `maintenance`
+- `maintenance`
+- `maintenance`
+- `bulk`
+- `bulk`
+- `bulk`
+- `bulk`
+- `compare`
+- `compare`
+- `compare`
+- `compare`
+- `release-mgmt`
+- `release-mgmt`
+- `release-mgmt`
+- `release-mgmt`
+- `release-mgmt`
+- `testing`
+- `testing`
+- `testing`
+- `testing`
+- `testing`
+- `automation`
+- `automation`
+- `automation`
+- `automation`
+- `automation`
+- `workflow`
+- `workflow`
+- `workflow`
+- `workflow`
+- `workflow`
+- `workflow`
+- `workflow`
+- `validate`
+- `extension`
+- `extension`
+- `extension`
+- `extension`
+- `extension`
+

--- a/docs/PLAN-multi-account.md
+++ b/docs/PLAN-multi-account.md
@@ -1,34 +1,33 @@
 # Multi-Account / Profile Support Implementation Plan
 
-**Status**: Blocked — waiting on asccli multi-account bugfixes to land first
-**Priority**: High
-**Date**: 2026-03-01
+**Status**: Phase 1–2 largely complete (2026-07-17) — CLI surface + profile resolution shipped  
+**Priority**: Medium (remaining polish)  
+**Date**: 2026-03-01 (updated 2026-07-17)
 
 ## Background
 
-The backend infrastructure for multi-account support already exists but the CLI surface is incomplete. Users currently can't switch between accounts without manually swapping `--key` flags or environment variables.
+The backend infrastructure for multi-account support already existed; the CLI surface was incomplete and parity docs overstated capabilities. As of 2026-07-17 the core profile commands and global resolution are implemented.
 
 ### What Already Works
 
 | Component | Location | Status |
 |-----------|----------|--------|
 | Profile-keyed token storage | `internal/auth/token_storage.go` | Working |
-| `tokenStorageKey("{profile}--{hash}")` | `token_storage.go:112-116` | Working |
-| `Manager.ListProfiles()` | `token_storage.go:69` | Working |
+| `tokenStorageKey("{profile}--{hash}")` | `token_storage.go` | Working |
+| `Manager.ListProfiles()` | `token_storage.go` | Working |
 | `SetActiveProfile()` / `GetActiveProfile()` | `internal/auth/auth.go` | Working |
-| `--profile` global CLI flag | `internal/cli/kong_cli.go:27` | Exists (not wired) |
-| `GPD_AUTH_PROFILE` env var | `internal/config/` | Defined (not read) |
-| `activeProfile` in config file | `internal/config/config.go` | Exists |
+| `--profile` global CLI flag | `internal/cli/kong_cli.go` | Wired via `ResolveAuthProfile` + `applyAuthGlobals` |
+| `GPD_AUTH_PROFILE` env var | `internal/config` | Read in `ResolveAuthProfile` |
+| `activeProfile` in config file | `internal/config/config.go` | Read + written by `SetActiveProfile` |
 | Token metadata files (`.meta.json`) | `internal/auth/token_storage.go` | Working |
 | Platform-specific secure storage | `internal/storage/` | Working |
+| `auth list/switch/init/login/check/doctor/diagnose` | `internal/cli/kong_auth.go` | Implemented |
 
-### What's Missing
+### Remaining gaps
 
-1. **CLI commands**: `auth switch`, `auth list`, `auth init` — documented in parity guides but not implemented
-2. **`--profile` flag propagation** — only `kong_reviews.go` calls `SetActiveProfile(globals.Profile)`; other commands ignore it
-3. **`GPD_AUTH_PROFILE` env var** — `GetEnvAuthProfile()` exists but is never called during CLI init
-4. **Profile deletion/cleanup** — no mechanism to remove a stored profile
-5. **Active profile persistence** — no way to remember which profile was last used across invocations
+1. **Profile deletion/cleanup** — no `auth delete` yet  
+2. **Logout profile targeting** — logout is not yet fully profile-file-aware (`--all` / secure-storage wipe)  
+3. **Per-command explicit profile on every API path** — globals are resolved centrally; some older helpers still construct managers independently (should keep using `newAuthManager()`)
 
 ## Implementation Steps
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Before using `gpd`, you'll need to set up authentication with a Google Cloud ser
 export GPD_SERVICE_ACCOUNT_KEY='{"type": "service_account", ...}'
 
 # Option 2: Key file
-gpd --key /path/to/service-account.json auth status
+gpd --key-path /path/to/service-account.json auth status
 
 # Option 3: Application Default Credentials
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
@@ -44,13 +44,20 @@ gpd auth status
 # Check permissions for a specific app
 gpd auth check --package com.example.app
 
-# Diagnose configuration issues
+# Diagnose auth + configuration issues
+gpd auth doctor --refresh-check
 gpd config doctor
 ```
+
+ASC users: see [Auth Parity Guide](auth-parity-guide.md), [ASC Parity Matrix](asc-parity.md), and [COMMANDS.md](COMMANDS.md).
 
 Then try your first commands:
 
 ```bash
+# Readiness + high-level ship (dry-run)
+gpd validate --package com.example.app --file app.aab --dry-run
+gpd publish play app.aab --package com.example.app --track internal --dry-run
+
 # Upload an app bundle
 gpd publish upload app.aab --package com.example.app
 

--- a/docs/asc-parity.md
+++ b/docs/asc-parity.md
@@ -1,69 +1,143 @@
 # App Store Connect CLI Parity Matrix
 
-This matrix maps App Store Connect CLI feature groups to `gpd` equivalents. Where Google Play has no direct analogue, the status is marked as not applicable. Links in the gpd column point to the most relevant reference or example documentation in this repo.
+**Last verified:** 2026-07-17 against:
 
-Status meanings:
-- Full: Comparable capability and scope
-- Partial: Similar capability with notable gaps or model differences
-- Not applicable: No Google Play equivalent
-- gpd-only: Google Play capability with no ASC equivalent
+- live `gpd --help` / `gpd auth --help` / `gpd publish --help` / `gpd validate --help`
+- generated [COMMANDS.md](COMMANDS.md) (`make generate-command-docs`)
+- [rorkai/App-Store-Connect-CLI](https://github.com/rorkai/App-Store-Connect-CLI) `docs/COMMANDS.md` (reference)
 
-## Parity Matrix
+This matrix maps App Store Connect CLI (`asc`) feature groups to `gpd` equivalents. It is intentionally **honest about model differences** and about what is implemented versus platform-impossible.
 
-| ASC Feature Group | ASC Commands (examples) | gpd Equivalent (docs) | Status |
+Related docs:
+
+- [Auth Parity Guide](auth-parity-guide.md)
+- [ASC Workflow Mapping](asc-workflow-mapping.md)
+- [Command taxonomy (generated)](COMMANDS.md)
+- [API Coverage Matrix](api-coverage-matrix.md)
+
+## Status meanings
+
+| Status | Meaning |
+| --- | --- |
+| **Full** | Comparable capability for day-to-day automation |
+| **Partial** | Similar goals with platform or product gaps |
+| **Not applicable** | No Google Play equivalent (Apple-only) |
+| **gpd-only** | Play capability with no ASC equivalent |
+
+## CLI contract (aligned where it matters)
+
+| Topic | ASC | gpd |
+| --- | --- | --- |
+| Framework | `ffcli`, domain packages | Kong (`internal/cli/kong_*.go`) |
+| Default `--output` | TTY-aware: `table` / pipe `json` | **TTY-aware:** `table` on TTY, `json` in pipes/CI; `GPD_DEFAULT_OUTPUT` + explicit `--output` win |
+| Destructive ops | `--confirm` | `--confirm` / `--dry-run` on mutating commands |
+| Auth | `.p8` API key + profiles + doctor | Service account / ADC / device flow + profiles + doctor |
+| High-level ship | `asc publish`, `asc validate`, `asc status` | `gpd publish play`, `gpd validate`, `gpd publish status` |
+| Command docs | generated `docs/COMMANDS.md` | generated `docs/COMMANDS.md` (`make generate-command-docs` / `make check-docs`) |
+| Install trust | checksum-verified install script | checksum-verified `install.sh` (`GPD_INSTALL_INSECURE=1` opt-out) |
+
+---
+
+## Parity matrix
+
+### Getting started & auth
+
+| ASC Feature Group | ASC Commands (examples) | gpd Equivalent | Status |
 | --- | --- | --- | --- |
-| Authentication | `asc auth login`, `asc auth switch`, `asc auth init`, `asc auth status`, `asc auth doctor`, `asc auth logout` | `gpd auth login`, `gpd auth init`, `gpd auth switch`, `gpd auth list`, `gpd auth status`, `gpd auth check`, `gpd auth diagnose`, `gpd auth doctor`, `gpd auth logout` ([Command Reference](../README.md#command-reference), [Auth Parity Guide](auth-parity-guide.md)) | Partial (device code OAuth + service accounts; no browser auth) |
-| Apps & Builds | `asc apps`, `asc builds list`, `asc builds info`, `asc builds expire`, `asc builds expire-all`, `asc builds upload`, `asc builds add-groups`, `asc builds remove-groups` | `gpd apps list`, `gpd apps get`, `gpd publish builds list`, `gpd publish builds get`, `gpd publish builds expire`, `gpd publish builds expire-all`, `gpd publish upload`, `gpd publish status`, `gpd publish tracks`, `gpd publish capabilities` ([API: Apps](api-coverage-matrix.md#apps), [API: Bundles/APKs](api-coverage-matrix.md#bundlesapks), [API: Tracks](api-coverage-matrix.md#tracks)) | Partial (no global build registry; no build-level beta group assignment) |
-| TestFlight | `asc feedback`, `asc crashes`, `asc testflight apps list`, `asc testflight apps get`, `asc testflight sync pull` | `gpd vitals crashes` ([Command Reference](../README.md#command-reference), [Error Debugging](examples/error-debugging.md)) | Partial (no feedback/testflight sync) |
-| Beta Groups | `asc beta-groups list`, `asc beta-groups create`, `asc beta-groups get`, `asc beta-groups update`, `asc beta-groups delete`, `asc beta-groups add-testers`, `asc beta-groups remove-testers` | `gpd publish beta-groups list/get/create/update/delete/add-testers/remove-testers`, `gpd publish testers list/get/add/remove` ([Command Reference](../README.md#command-reference)) | Partial (compatibility commands map groups to internal/alpha/beta tracks; no standalone group object in Play API) |
-| Beta Testers | `asc beta-testers list`, `asc beta-testers get`, `asc beta-testers add`, `asc beta-testers remove`, `asc beta-testers invite`, `asc beta-testers add-groups`, `asc beta-testers remove-groups` | `gpd publish testers list`, `gpd publish testers get`, `gpd publish testers add`, `gpd publish testers remove` ([Command Reference](../README.md#command-reference)) | Partial (track-based, no invite lifecycle) |
-| Devices | `asc devices list`, `asc devices get`, `asc devices register`, `asc devices update` | N/A | Not applicable |
-| App Store | `asc reviews`, `asc reviews respond`, `asc reviews response get`, `asc reviews response for-review`, `asc reviews response delete` | `gpd reviews list`, `gpd reviews get`, `gpd reviews reply`, `gpd reviews response-get`, `gpd reviews response-delete`, `gpd reviews capabilities` ([API: Reviews](api-coverage-matrix.md#reviews)) | Partial (`gpd reviews response-delete` exists but returns platform limitation: deletion unsupported by Google Play API) |
-| App Tags | `asc app-tags list`, `asc app-tags get`, `asc app-tags update`, `asc app-tags territories`, `asc app-tags territories-relationships`, `asc app-tags relationships` | N/A | Not applicable |
-| App Events | `asc app-events list`, `asc app-events localizations list`, `asc app-events localizations screenshots list`, `asc app-events localizations video-clips list`, `asc app-events relationships`, `asc app-events localizations screenshots-relationships`, `asc app-events localizations video-clips-relationships` | N/A | Not applicable |
-| Alternative Distribution | `asc alternative-distribution domains list`, `asc alternative-distribution domains create`, `asc alternative-distribution domains delete`, `asc alternative-distribution keys list`, `asc alternative-distribution keys create`, `asc alternative-distribution keys app`, `asc alternative-distribution packages create`, `asc alternative-distribution packages get`, `asc alternative-distribution packages versions list`, `asc alternative-distribution packages versions get`, `asc alternative-distribution packages versions deltas`, `asc alternative-distribution packages versions variants` | N/A | Not applicable |
-| Analytics & Sales | `asc analytics sales`, `asc analytics request`, `asc analytics requests`, `asc analytics get`, `asc analytics download` | `gpd analytics query`, `gpd analytics capabilities`, `gpd vitals crashes`, `gpd vitals anrs` ([Command Reference](../README.md#command-reference), [Error Debugging](examples/error-debugging.md)) | Partial (Play Reporting focus) |
-| Finance Reports | `asc finance reports`, `asc finance regions` | N/A | Not applicable |
-| Sandbox Testers | `asc sandbox list`, `asc sandbox get`, `asc sandbox update`, `asc sandbox clear-history` | N/A | Not applicable |
-| Xcode Cloud | `asc xcode-cloud workflows`, `asc xcode-cloud build-runs`, `asc xcode-cloud run`, `asc xcode-cloud status` | N/A | Not applicable |
-| Game Center | `asc game-center achievements`, `asc game-center leaderboards`, `asc game-center leaderboard-sets` | `gpd games achievements`, `gpd games scores`, `gpd games events`, `gpd games players`, `gpd grouping` ([API: Play Games Services](api-coverage-matrix.md#play-games-services-api-v1), [API: Games Management](api-coverage-matrix.md#games-management-api-v1)) | Partial (different feature set) |
-| App Setup | `asc app-setup info set`, `asc app-setup categories set`, `asc app-setup availability set`, `asc app-setup pricing set`, `asc app-setup localizations upload` | `gpd publish listing update`, `gpd publish details update`, `gpd publish images upload`, `gpd publish assets upload`, `gpd publish assets spec` ([API: Listings](api-coverage-matrix.md#listings), [API: Images](api-coverage-matrix.md#images), [API: App Details](api-coverage-matrix.md#app-details)) | Partial (pricing/availability differ) |
-| Categories | `asc categories list`, `asc categories set` | N/A | Not applicable |
-| Versions | `asc versions list`, `asc versions get`, `asc versions attach-build`, `asc versions release`, `asc versions phased-release get`, `asc versions phased-release create`, `asc versions phased-release update`, `asc versions phased-release delete`, `asc versions promotions create` | `gpd publish release`, `gpd publish rollout`, `gpd publish promote`, `gpd publish halt`, `gpd publish rollback`, `gpd publish status`, `gpd release-mgmt calendar`, `gpd release-mgmt history`, `gpd release-mgmt notes` ([API: Tracks](api-coverage-matrix.md#tracks), [Edit Workflow](examples/edit-workflow.md), [Release Workflow](examples/release-workflow.md)) | Partial (workflow and concepts differ) |
-| App Info | `asc app-info get`, `asc app-info set` | `gpd publish listing get`, `gpd publish listing update`, `gpd publish details get`, `gpd publish details update` ([API: Listings](api-coverage-matrix.md#listings), [API: App Details](api-coverage-matrix.md#app-details)) | Partial (workflow and scope differ) |
-| Pre-Release Versions | `asc pre-release-versions list`, `asc pre-release-versions get` | N/A | Not applicable |
-| Localizations | `asc localizations list`, `asc localizations download`, `asc localizations upload` | `gpd publish listing get`, `gpd publish listing update`, `gpd publish images upload` ([API: Listings](api-coverage-matrix.md#listings), [API: Images](api-coverage-matrix.md#images)) | Partial (scope and workflow differ) |
-| Build Localizations | `asc build-localizations list`, `asc build-localizations create`, `asc build-localizations update`, `asc build-localizations delete`, `asc build-localizations get` | N/A | Not applicable |
-| Offer Codes (Subscriptions) | `asc offer-codes list`, `asc offer-codes generate`, `asc offer-codes values` | N/A | Not applicable |
-| In-App Purchases & Subscriptions | `asc in-app-purchases`, `asc subscriptions`, `asc subscription-groups` | `gpd monetization products`, `gpd monetization subscriptions`, `gpd monetization base-plans`, `gpd monetization offers` ([API: Monetization - Subscriptions](api-coverage-matrix.md#monetization---subscriptions), [API: Base Plans](api-coverage-matrix.md#monetization---base-plans), [API: Offers](api-coverage-matrix.md#monetization---offers), [API: In-app Products](api-coverage-matrix.md#monetization---in-app-products), [Subscription Management](examples/subscription-management.md)) | Partial (model differs) |
-| Migrate (Fastlane Compatibility) | `asc migrate validate`, `asc migrate import`, `asc migrate export` | `gpd migrate` ([Command Reference](../README.md#command-reference)) | Full |
-| Submit | `asc submit create`, `asc submit status`, `asc submit cancel` | `gpd publish release`, `gpd publish rollout`, `gpd publish promote`, `gpd publish halt`, `gpd publish rollback` ([API: Tracks](api-coverage-matrix.md#tracks), [Edit Workflow](examples/edit-workflow.md), [Release Workflow](examples/release-workflow.md)) | Partial (workflow and concepts differ) |
-| Utilities | `asc version` | `gpd version`, `gpd config init`, `gpd config doctor`, `gpd config path`, `gpd config get`, `gpd config set`, `gpd config completion` ([Command Reference](../README.md#command-reference)) | Partial (additional utilities available) |
-| Output Formats | `asc --output table`, `asc --output markdown` | `gpd --output json`, `gpd --output table`, `gpd --output markdown` ([Command Reference](../README.md#command-reference)) | Full |
+| Authentication | `asc auth login/init/switch/status/doctor/logout` | `gpd auth login/init/switch/list/status/check/doctor/diagnose/logout` ([Auth Parity Guide](auth-parity-guide.md)) | **Partial** — multi-profile CLI implemented; credentials are service-account/ADC/device-flow, not ASC `.p8` |
+| Config / doctor | `asc doctor`, `asc init`, `asc docs` | `gpd config *`, `gpd auth doctor` | **Partial** — no embedded docs browser / install-skills |
+| Output formats | `--output table\|json\|markdown`, TTY defaults | `--output json\|table\|markdown\|csv\|excel`, TTY defaults, `GPD_DEFAULT_OUTPUT` | **Full** for day-to-day use |
+| Version / completion | `asc version`, `asc completion` | `gpd version`, `gpd completion`, `gpd check-update` | **Full** |
 
-## gpd Features Without ASC Equivalent
+### Apps, builds, distribution
 
-| gpd Feature Group | gpd Commands (examples) | Docs | Status |
+| ASC Feature Group | ASC Commands (examples) | gpd Equivalent | Status |
 | --- | --- | --- | --- |
-| Permissions & Access | `gpd permissions users`, `gpd permissions grants` | [API: Users](api-coverage-matrix.md#users), [API: Grants](api-coverage-matrix.md#grants) | gpd-only |
-| Edit Transactions | `gpd publish edit create`, `gpd publish edit validate`, `gpd publish edit commit` | [API: Edits](api-coverage-matrix.md#edits), [Edit Workflow](examples/edit-workflow.md) | gpd-only |
-| Internal App Sharing | `gpd publish internal-share upload` | [API: Internal App Sharing](api-coverage-matrix.md#internal-app-sharing) | gpd-only |
-| Deobfuscation Uploads | `gpd publish deobfuscation upload` | [API: Deobfuscation Files](api-coverage-matrix.md#deobfuscation-files) | gpd-only |
-| Purchases Verification | `gpd purchases verify`, `gpd purchases products acknowledge`, `gpd purchases subscriptions revoke`, `gpd purchases voided list` | [API: Purchases - Products](api-coverage-matrix.md#purchases---products), [API: Purchases - Subscriptions](api-coverage-matrix.md#purchases---subscriptions), [API: Purchases - Voided](api-coverage-matrix.md#purchases---voided) | gpd-only |
-| Play Integrity | `gpd integrity decode` | [API: Play Integrity](api-coverage-matrix.md#play-integrity-api-v1) | gpd-only |
-| App Recovery | `gpd recovery create`, `gpd recovery deploy`, `gpd recovery cancel` | [API: App Recovery](api-coverage-matrix.md#app-recovery) | gpd-only |
-| Android Vitals Error Reporting | `gpd vitals errors issues`, `gpd vitals errors reports`, `gpd vitals errors counts`, `gpd vitals anomalies`, `gpd vitals metrics` | [API: Error Issues Search](api-coverage-matrix.md#error-issues-search), [API: Anomalies](api-coverage-matrix.md#anomalies), [Error Debugging](examples/error-debugging.md) | gpd-only |
-| Custom App Publishing | `gpd customapp create` | [API: Custom App Publishing](api-coverage-matrix.md#play-custom-app-publishing-api-v1) | gpd-only |
-| Bulk Operations | `gpd bulk upload`, `gpd bulk listings`, `gpd bulk images`, `gpd bulk tracks` | [Bulk Operations](examples/bulk-operations.md) | gpd-only |
-| Multi-App Comparison | `gpd compare vitals`, `gpd compare reviews`, `gpd compare releases`, `gpd compare subscriptions` | [Multi-App Comparison](examples/multi-app-comparison.md) | gpd-only |
-| Release Management | `gpd release-mgmt calendar`, `gpd release-mgmt conflicts`, `gpd release-mgmt strategy`, `gpd release-mgmt history`, `gpd release-mgmt notes` | [Release Workflow](examples/release-workflow.md) | gpd-only |
-| Testing & Validation | `gpd testing prelaunch`, `gpd testing device-lab`, `gpd testing screenshots`, `gpd testing validate`, `gpd testing compatibility` | [Testing Guide](examples/testing-validation.md) | gpd-only |
-| Automation Workflows | `gpd automation release-notes`, `gpd automation rollout`, `gpd automation promote`, `gpd automation validate`, `gpd automation monitor` | [Automation Workflows](examples/automation-workflows.md) | gpd-only |
-| Continuous Monitoring | `gpd monitor watch`, `gpd monitor anomalies`, `gpd monitor dashboard`, `gpd monitor report`, `gpd monitor webhooks` | [Monitoring Setup](examples/monitoring-setup.md) | gpd-only |
-| Play Grouping API | `gpd grouping`, `gpd grouping token`, `gpd grouping token-recall` | [API: Play Grouping](api-coverage-matrix.md#play-grouping-api) | gpd-only |
+| Apps | `asc apps list/get` | `gpd apps list`, `gpd apps get` | **Partial** |
+| Builds | `asc builds upload/list/...` | `gpd publish upload`, `gpd publish builds *`, `gpd publish play` | **Partial** — track/edit model, not global build registry |
+| TestFlight | `asc testflight`, feedback, crashes | `gpd vitals *`, `gpd publish testers`, `gpd publish beta-groups` | **Partial** |
+| Beta groups / testers | `asc beta-groups`, `asc beta-testers` | `gpd publish beta-groups *`, `gpd publish testers *` | **Partial** |
+| Internal sharing | N/A | `gpd publish internal-share upload` | **gpd-only** |
+| Deobfuscation | N/A | `gpd publish deobfuscation upload` | **gpd-only** |
+| Devices / signing / Xcode / sandbox | `asc devices`, certificates, xcode-cloud, sandbox | N/A | **Not applicable** |
 
-## Notes
+### Metadata & media
 
-- Some ASC features (Devices, Xcode Cloud, Sandbox Testers, App Tags, App Events, Finance Reports, Alternative Distribution) have no Google Play equivalents.
-- Some gpd features (Play Integrity, App Recovery, Deobfuscation, Purchases, Edit Transactions, Permissions & Access, Bulk Operations, Comparison Tools, Release Management, Testing, Automation, Monitoring) have no ASC equivalents.
-- For the full Google Play API-to-command mapping, see [API Coverage Matrix](api-coverage-matrix.md).
+| ASC Feature Group | ASC Commands (examples) | gpd Equivalent | Status |
+| --- | --- | --- | --- |
+| Listing / localizations | `asc localizations`, `asc metadata` | `gpd publish listing *`, `gpd publish details *` | **Partial** |
+| Screenshots / assets | `asc screenshots` | `gpd publish images *`, `gpd publish assets *` | **Partial** |
+| App tags / events / clips / categories / pre-orders | ASC-only | N/A | **Not applicable** |
+
+### Review & release
+
+| ASC Feature Group | ASC Commands (examples) | gpd Equivalent | Status |
+| --- | --- | --- | --- |
+| Customer reviews | `asc reviews` | `gpd reviews list/get/reply/response-*` | **Partial** — response delete limited by Play API |
+| Validate / readiness | `asc validate` | `gpd validate` (dry-run readiness report) | **Partial** — local + plan; live network probes via `auth check` / publish status |
+| High-level publish | `asc publish appstore\|testflight` | `gpd publish play` (upload→track→status), plus primitives | **Partial** — Play track model |
+| Status | `asc status --watch` | `gpd publish status`, `gpd monitor *`, `gpd automation monitor` | **Partial** |
+| Versions / phased release | `asc versions`, phased-release | `gpd publish rollout`, `gpd release-mgmt *` | **Partial** |
+
+### Analytics, finance, ads
+
+| ASC Feature Group | gpd Equivalent | Status |
+| --- | --- | --- |
+| Analytics & sales | `gpd analytics *`, `gpd vitals *` | **Partial** |
+| Finance / Apple Ads | N/A | **Not applicable** |
+
+### Monetization & games
+
+| ASC Feature Group | gpd Equivalent | Status |
+| --- | --- | --- |
+| IAP & subscriptions | `gpd monetization *` | **Partial** |
+| Purchase verification | `gpd purchases *` | **gpd-only** (stronger on Play) |
+| StoreKit retention | N/A | **Not applicable** |
+| Game Center | `gpd games *`, `gpd grouping` | **Partial** |
+
+### Automation & tooling
+
+| ASC Feature Group | gpd Equivalent | Status |
+| --- | --- | --- |
+| Workflows | `gpd workflow *` | **Full** for declarative multi-step runs (schema differs) |
+| Migrate (Fastlane) | `gpd migrate` | **Partial** |
+| Agent skills | [`skills/`](../skills/README.md) (`gpd-auth`, `gpd-release`, `gpd-reviews-vitals`) | **Partial** (packaged skills; not a runtime installer) |
+| Extensions | `gpd extension *` | **gpd-only** |
+| Telemetry / snitch / schema search | N/A or not implemented | **Not applicable** |
+
+---
+
+## gpd features without ASC equivalent
+
+Permissions, edit lifecycle depth, internal sharing, deobfuscation, purchases, integrity, recovery, vitals depth, custom apps, generated/system APKs, bulk, compare, release-mgmt, testing, automation, monitor, maintenance/API drift, extensions.
+
+---
+
+## Intentionally not mirrored (Apple-only)
+
+Devices, certificates, profiles, bundle IDs, notarization, Xcode / Xcode Cloud, sandbox testers, App Tags/Events/Clips, alternative distribution, Apple Ads, ASC finance, StoreKit retention, web-session scraping.
+
+---
+
+## Remaining product gaps
+
+Optional / later:
+
+1. Broader domain package migration for remaining large `kong_*.go` families (beyond `outfmt` + `playship`)  
+2. Even deeper `validate` (media matrix, content rating, all listing locales)  
+3. Publish production tag `v0.6.5+` so GitHub Releases use the new archive + checksum names end-to-end  
+
+**Delivered recently:** TTY-aware output; checksum install + GoReleaser SHA-256 (snapshot verified); generated command docs; `validate` (package/track/listing network probes) + `publish play`; multi-profile auth including **delete/logout**; `setup-gpd` action; agent **skills/** pack; `outfmt` + `playship` extractions.
+
+---
+
+## Maintenance rule
+
+When adding or removing a user-facing command:
+
+1. `make generate-command-docs` and commit `docs/COMMANDS.md`  
+2. `make check-docs` must pass  
+3. Update this matrix if ASC parity status changes  
+4. Prefer live `gpd <cmd> --help` over inventing flags in docs  
+
+For Play API endpoint mapping (not ASC), see [API Coverage Matrix](api-coverage-matrix.md).

--- a/docs/asc-workflow-mapping.md
+++ b/docs/asc-workflow-mapping.md
@@ -1,94 +1,267 @@
 # ASC Workflow Mapping (Submit, Builds, Analytics, Localization)
 
-This guide maps common App Store Connect (ASC) operational workflows to `gpd` command sequences, including known Google Play model differences.
+**Last verified:** 2026-07-17 against live `gpd --help`, `gpd validate`, and `gpd publish play`.
 
-## 1) Submit / Release Workflow Mapping
+Maps common App Store Connect (`asc`) operational workflows to `gpd` sequences, including Google Play model differences.
 
-### ASC-style goal: create a release and submit for review
+See also: [ASC Parity Matrix](asc-parity.md), [Auth Parity Guide](auth-parity-guide.md).
 
-Google Play equivalent is track-based release management:
+---
 
-```bash
-# Draft release to internal track
-gpd publish release --package <pkg> --track internal --status draft
+## Mental model
 
-# Roll out to a percentage
-gpd publish rollout --package <pkg> --track production --percentage 10
+| Concept | ASC | Google Play / gpd |
+| --- | --- | --- |
+| App identity | Numeric App Store Connect app ID (`--app`) | Package name (`--package` / `-p`) |
+| Binary | Build → version → review | AAB/APK upload inside an **edit**, assigned to a **track** |
+| Beta | TestFlight groups | Tracks: `internal` → `alpha` → `beta` → `production` |
+| Staged release | Phased release on a version | Rollout **user fraction** on a track |
+| Submit for review | `submit` / `publish appstore --submit` | Promoting/completing a track release (no Apple-style review queue) |
+| High-level ship | `asc publish`, `asc release stage`, `asc status --watch` | Compose `publish *` or use `automation` / `workflow` |
 
-# Check status
-gpd publish status --package <pkg> --track production
+---
 
-# Halt rollout
-gpd publish halt --package <pkg> --track production
+## 1) Submit / release workflow
 
-# Rollback
-gpd publish rollback --package <pkg> --track production
+### ASC-style goal: upload, attach, submit, watch
 
-# Promote track
-gpd publish promote --package <pkg> --from-track internal --to-track production
-```
-
-### Decision paths
-
-- Increase staged rollout when metrics are healthy.
-- Halt when regressions appear.
-- Roll back if user impact is severe.
-- Promote when lower environment validation is complete.
-
-## 2) Apps & Builds Model Differences
-
-ASC and Google Play differ in artifact and distribution models:
-
-- ASC has a broader build registry view with TestFlight group semantics.
-- Google Play is track-oriented for distribution and tester access.
-
-### Recommended Play-native alternatives
-
-- Use tracks as environment gates (internal -> alpha -> beta -> production).
-- Use tester commands at track scope:
-  - `gpd publish testers list`
-  - `gpd publish testers add`
-  - `gpd publish testers remove`
-
-## 3) Analytics & Reporting Scope Differences
-
-`gpd` covers Play Reporting and Android vitals-focused data, which does not fully mirror ASC analytics/sales breadth.
-
-### Supported focus areas
-
-- Android vitals anomalies, crashes, and ANR insights.
-- Query-based analytics where exposed by Play reporting endpoints.
-
-### Practical guidance
-
-- Use `gpd analytics query` and vitals commands for API-available data.
-- For unsupported ASC-analog metrics, use Play Console exports or complementary BI pipelines.
-
-## 4) Metadata & Localization Task Mapping
-
-### ASC task -> gpd sequence examples
-
-1. Update listing text/localization
+ASC (illustrative):
 
 ```bash
-gpd publish listing get --package <pkg> --language en-US
-gpd publish listing update --package <pkg> --language en-US --title "..." --short-description "..."
+asc publish appstore --app "123" --ipa app.ipa --version "1.2.3" --submit --confirm
+asc status --app "123" --watch
+asc validate --app "123" --version "1.2.3"
 ```
 
-2. Update app details
+### gpd Play-native sequence
 
 ```bash
-gpd publish details get --package <pkg>
-gpd publish details update --package <pkg> --contact-email ops@example.com
+# Upload to internal track (creates/commits edit by default)
+gpd publish upload ./app.aab --package com.example.app --track internal
+
+# Create/update a release on a track
+gpd publish release --package com.example.app --track internal --status draft
+
+# Staged production rollout
+gpd publish rollout --package com.example.app --track production --percentage 10
+
+# Status
+gpd publish status --package com.example.app --track production
+gpd publish tracks --package com.example.app
+
+# Halt / rollback / promote
+gpd publish halt --package com.example.app --track production --confirm
+gpd publish rollback --package com.example.app --track production --confirm
+gpd publish promote --package com.example.app --from-track internal --to-track production
 ```
 
-3. Upload localization images
+### Higher-level gpd helpers (ASC “job command” spirit)
 
 ```bash
-gpd publish images upload --package <pkg> --language en-US --image-type phone-screenshots --file ./shot1.png
+# Readiness report (ASC validate analogue; dry-run by default)
+gpd validate --package com.example.app --track internal --dry-run
+gpd validate --package com.example.app --track production --file ./app.aab --dry-run
+
+# Composed ship job (ASC publish analogue)
+gpd publish play ./app.aab --package com.example.app --track internal --dry-run
+gpd publish play ./app.aab --package com.example.app --track production --percentage 10
+
+gpd automation validate --package com.example.app
+gpd automation rollout --package com.example.app --track production
+gpd automation promote --package com.example.app
+gpd automation monitor --package com.example.app
+gpd release-mgmt history --package com.example.app
+gpd release-mgmt strategy --package com.example.app
 ```
 
-### Known boundaries
+### Declarative workflow (both CLIs)
 
-- Localization workflow follows Play listing/image models rather than ASC's exact structure.
-- Pricing/availability and certain metadata flows differ conceptually and operationally.
+```bash
+gpd workflow validate --file ./workflows/production-release.json
+gpd workflow run --file ./workflows/production-release.json
+gpd workflow status
+```
+
+Example workflows live under `docs/examples/workflows/`.
+
+### Decision paths (Play)
+
+- Increase staged rollout when vitals/reviews look healthy (`publish rollout`, `automation rollout`).  
+- Halt when regressions appear (`publish halt`).  
+- Roll back if impact is severe (`publish rollback`).  
+- Promote when lower tracks validate (`publish promote` / `automation promote`).
+
+---
+
+## 2) Builds & TestFlight → tracks & testers
+
+### ASC
+
+```bash
+asc builds upload --app "123" --ipa app.ipa
+asc builds list --app "123"
+asc testflight groups list --app "123"
+asc builds add-groups --app "123" --group "Internal Testers" ...
+```
+
+### gpd
+
+```bash
+gpd publish upload ./app.aab --package com.example.app --track internal
+gpd publish builds list --package com.example.app
+gpd publish builds get --package com.example.app
+gpd publish testers list --package com.example.app
+gpd publish testers add --package com.example.app --track internal --group "testers@example.com"
+gpd publish beta-groups list --package com.example.app   # ASC-compat naming over tracks
+```
+
+**Model difference:** ASC attaches builds to TestFlight groups. Play grants testers access via **track** membership (and Google Groups). `beta-groups` commands are a compatibility veneer, not a second object model.
+
+Internal sharing (no ASC twin):
+
+```bash
+gpd publish internal-share upload ./app.aab --package com.example.app
+```
+
+---
+
+## 3) Analytics & crash feedback
+
+### ASC
+
+```bash
+asc analytics sales ...
+asc testflight feedback list --app "123"
+asc testflight crashes list --app "123"
+```
+
+### gpd
+
+```bash
+gpd analytics query --package com.example.app ...
+gpd analytics capabilities
+gpd vitals crashes --package com.example.app
+gpd vitals anrs --package com.example.app
+gpd vitals errors issues --package com.example.app
+gpd vitals anomalies list --package com.example.app
+gpd monitor watch --package com.example.app
+```
+
+**Scope difference:** ASC sales/finance reports and TestFlight feedback are not the same APIs as Play Reporting + Android vitals. For metrics outside API coverage, use Play Console exports / BI.
+
+---
+
+## 4) Metadata & localization
+
+### ASC
+
+```bash
+asc localizations list --app "123" --type app-info
+asc metadata apply --app "123" --version "1.2.3" --dir ./metadata --dry-run
+asc screenshots apply --app "123" --version "1.2.3" ...
+```
+
+### gpd
+
+```bash
+# Listing copy
+gpd publish listing get --package com.example.app --language en-US
+gpd publish listing update --package com.example.app --language en-US \
+  --title "..." --short-description "..."
+
+# Contact / app details
+gpd publish details get --package com.example.app
+gpd publish details update --package com.example.app --contact-email ops@example.com
+
+# Images / assets
+gpd publish images upload --package com.example.app --language en-US \
+  --image-type phone-screenshots --file ./shot1.png
+gpd publish images list --package com.example.app --language en-US
+gpd publish assets upload --package com.example.app --dir ./store-assets
+gpd publish assets spec
+
+# Bulk locale updates
+gpd bulk listings --package com.example.app --data-file ./listings.json
+```
+
+**Boundaries:** No ASC metadata directory sync or keyword audit. Pricing/availability and categories do not map 1:1.
+
+---
+
+## 5) Reviews (customer)
+
+### ASC
+
+```bash
+asc reviews list --app "123"
+asc reviews respond ...
+```
+
+### gpd
+
+```bash
+gpd reviews list --package com.example.app --min-rating 1
+gpd reviews get --package com.example.app ...
+gpd reviews reply --package com.example.app ...
+gpd reviews response-get --package com.example.app ...
+# response-delete exists but Play API may not support deletion
+gpd reviews response-delete --package com.example.app ...
+```
+
+---
+
+## 6) Auth for workflows (CI)
+
+### ASC
+
+```bash
+asc auth login --bypass-keychain --name ci --key-id ... --issuer-id ... --private-key ./AuthKey.p8
+asc auth status --validate
+```
+
+### gpd
+
+```bash
+gpd auth login ci --key-path ./sa.json
+# or: export GOOGLE_APPLICATION_CREDENTIALS=./sa.json
+gpd auth status
+gpd auth check --package com.example.app
+gpd auth doctor --refresh-check
+```
+
+In CI, prefer:
+
+```bash
+gpd --key-path "$SA_JSON" --store-tokens never publish upload ...
+```
+
+---
+
+## 7) What not to force-map
+
+These ASC workflows should stay Apple-side:
+
+- Signing / devices / profiles / certificates  
+- Xcode archive/export / Xcode Cloud  
+- Sandbox testers, App Clips, App Events, alternative distribution  
+- Apple Ads campaigns, ASC finance downloads  
+- StoreKit retention messaging  
+
+Play-native replacements live under vitals, monetization, integrity, recovery, and permissions — see the [parity matrix](asc-parity.md).
+
+---
+
+## Quick cheat sheet
+
+| Job | Start here |
+| --- | --- |
+| Readiness | `gpd validate --package … --dry-run` |
+| Ship a build | `gpd publish play app.aab --package … --track …` (or `publish upload`) |
+| Staged production | `gpd publish play … --percentage N` / `publish rollout` |
+| Stop a bad rollout | `gpd publish halt --confirm` |
+| Beta testers | `gpd publish testers` / `beta-groups` |
+| Crashes | `gpd vitals crashes` / `errors` |
+| Store copy | `gpd publish listing` / `images` / `assets` |
+| Reviews | `gpd reviews list` / `reply` |
+| Multi-step CI | `gpd workflow run` or `gpd automation *` |
+| Auth health | `gpd auth doctor --refresh-check` |

--- a/docs/auth-parity-guide.md
+++ b/docs/auth-parity-guide.md
@@ -1,65 +1,155 @@
-# Authentication Parity Guide (ASC -> gpd)
+# Authentication Parity Guide (ASC → gpd)
 
-This guide explains how App Store Connect (ASC) auth workflows map to `gpd`, where behavior differs, and what to do in migration scenarios.
+**Last verified:** 2026-07-17 against live `gpd auth --help` and generated [COMMANDS.md](COMMANDS.md).
 
-## Auth Model Differences
+This guide maps App Store Connect CLI auth workflows to `gpd`, documents real commands (not aspirational ones), and explains migration choices.
 
-- ASC commonly uses browser-based login sessions and key-based automation.
-- `gpd` supports:
-  - Service account credentials (recommended for CI/automation).
-  - OAuth device flow (`gpd auth login`) for user-based interactive auth.
-- `gpd` does not use browser redirect login in the same way as ASC CLI flows.
+## Auth model differences
 
-## Decision Tree
+| | ASC | gpd |
+| --- | --- | --- |
+| Primary credential | App Store Connect API key (`.p8` + key ID + issuer ID) | Google **service account** JSON (recommended for CI) |
+| Interactive human auth | Key registration; optional web session flows elsewhere | OAuth **device flow** when client ID is configured |
+| Storage | System keychain with config fallback (`--bypass-keychain`) | Platform secure storage (`--store-tokens auto\|never\|secure`) |
+| Profiles | Named keys (`--name`, `auth switch`) | Named profiles (`auth login <profile>`, `auth switch`, `--profile`, `GPD_AUTH_PROFILE`) |
+| Diagnostics | `asc auth status --validate`, `asc auth doctor` / `asc doctor` | `gpd auth status`, `gpd auth doctor` / `diagnose`, `gpd config doctor` |
+| Package access check | Network validate on login (`--network`) | `gpd auth check --package <pkg>` (edits insert/delete probe) |
 
-Use this to pick the right auth path.
+`gpd` does **not** use ASC-style browser redirect login for Play automation. Prefer service accounts in CI.
 
-1. Need unattended CI/CD automation?
-   - Use service account auth (`--key` or `GOOGLE_APPLICATION_CREDENTIALS`).
-2. Need human interactive access for support/ops workflows?
-   - Use `gpd auth login` (device flow).
-3. Need to manage multiple personas or environments?
-   - Use profile-based auth (`gpd auth login <profile>`, `gpd auth switch <profile>`, `gpd auth list`).
-4. Seeing refresh failures (`invalid_grant`) during OAuth usage?
-   - Re-authenticate, revoke stale tokens, and verify OAuth consent screen mode.
+## Implemented commands (source of truth)
 
-## Command Mapping (ASC -> gpd)
+```bash
+gpd auth status                 # Auth status (profile, origin, token validity)
+gpd auth login [profile]        # Authenticate (service account --key / env / ADC)
+gpd auth init [profile]         # Alias of login (ASC naming parity)
+gpd auth logout [--name name | --all]     # Clear stored credentials for active/named/all profiles
+gpd auth delete <profile> [--force]       # Remove a profile (refuse active unless --force)
+gpd auth list                   # List stored profiles + active marker
+gpd auth switch <profile>       # Persist active profile to config
+gpd auth check --package ...    # Validate Play API access for a package
+gpd auth doctor                 # Sectioned diagnostics report
+gpd auth diagnose               # Alias of doctor
+```
 
-- `asc auth login` -> `gpd auth login`
-- `asc auth init` -> `gpd auth init`
-- `asc auth switch` -> `gpd auth switch <profile>`
-- `asc auth status` -> `gpd auth status`
-- `asc auth doctor` -> `gpd auth diagnose` (or `gpd auth doctor`)
-- `asc auth logout` -> `gpd auth logout`
+Global flags that affect auth:
 
-## Migration Guidance for ASC Users
+| Flag / env | Role |
+| --- | --- |
+| `--key-path` / service account path on login | Explicit key file |
+| `--profile` | Override active profile for this invocation |
+| `GPD_AUTH_PROFILE` | Env override for profile |
+| `GPD_SERVICE_ACCOUNT_KEY` | Inline JSON key |
+| `GOOGLE_APPLICATION_CREDENTIALS` | ADC key path |
+| `GPD_CLIENT_ID` / `GPD_CLIENT_SECRET` | Device-flow OAuth (when used) |
+| `--store-tokens` | `auto` (default), `never`, `secure` |
 
-1. Service-account-first migration (recommended)
-   - Provision a Google service account with Android Publisher permissions.
-   - Prefer `gpd --key /path/key.json ...` in CI jobs.
-   - Validate with `gpd auth status` and `gpd auth check --package <pkg>`.
+### Profile resolution order
 
-2. User flow migration
-   - Use `gpd auth login` to authorize via device flow.
-   - Use profile names to separate teams/apps: `gpd auth login team-a`, `gpd auth switch team-a`.
+1. `--profile` flag  
+2. `GPD_AUTH_PROFILE`  
+3. `activeProfile` in config file  
+4. `default`
 
-3. Operational diagnostics
-   - Use `gpd auth diagnose --refresh-check` to inspect token source, scopes, storage, and refresh outcomes.
+`gpd auth switch <profile>` and successful `auth login` / `auth init` persist `activeProfile` via `config.SetActiveProfile`.
 
-## OAuth Testing-Mode Constraints
+## Command mapping (ASC → gpd)
 
-If your OAuth consent screen is in testing mode:
+| ASC | gpd | Notes |
+| --- | --- | --- |
+| `asc auth login --name ... --key-id ... --issuer-id ... --private-key ...` | `gpd auth login [profile] --key-path key.json` | Different credential material |
+| `asc auth init` | `gpd auth init [profile]` | gpd init authenticates; ASC init scaffolds config template |
+| `asc auth switch` | `gpd auth switch <profile>` | Implemented |
+| `asc auth status` / `--validate` | `gpd auth status` | Use `auth check` for package validation |
+| `asc auth doctor` / `asc doctor` | `gpd auth doctor` / `gpd auth diagnose` | Structured sections + summary; `--refresh-check`, `--network` |
+| `asc auth logout` | `gpd auth logout [--name name \| --all]` | Clears stored tokens for the active profile by default |
+| (profile delete) | `gpd auth delete <profile> [--force]` | Refuses the active profile unless `--force` (then switches to `default`) |
+| (login `--network`) | `gpd auth check --package ...` | Explicit package permission probe |
+| `asc auth login --bypass-keychain` | `--store-tokens never` or CI env without secure storage | Closest operational equivalent |
 
-- Refresh tokens can expire after 7 days.
-- Google enforces a 100 refresh-token issuance cap per OAuth client.
+## Decision tree
 
-If you hit recurring `invalid_grant` errors:
+1. **Unattended CI/CD?**  
+   Use a service account with Android Publisher access.  
+   `gpd --key-path /secrets/sa.json ...` or `GOOGLE_APPLICATION_CREDENTIALS`.  
+   Prefer `--store-tokens never` in CI.
 
-1. Re-authenticate with `gpd auth login`.
-2. Revoke stale tokens in Google Cloud Console.
-3. Move OAuth consent screen to production for stable long-lived behavior.
+2. **Human ops / support on a laptop?**  
+   `gpd auth login team-ops --key-path ./sa.json`  
+   or device flow when OAuth client is configured.
 
-## Known Boundaries
+3. **Multiple apps/teams?**  
+   ```bash
+   gpd auth login team-a --key-path ./team-a.json
+   gpd auth login team-b --key-path ./team-b.json
+   gpd auth switch team-a
+   gpd --profile team-b publish status --package com.example.b
+   ```
 
-- No ASC-identical browser login UX; device flow and service accounts are the supported models.
-- `gpd` auth behavior is optimized for explicit CLI/automation usage with JSON output and diagnosable failure modes.
+4. **Auth failures / invalid_grant (OAuth)?**  
+   Re-login, revoke stale tokens, move OAuth consent to production if stuck in testing mode (7-day refresh tokens, 100-token cap).
+
+## Doctor report shape
+
+`gpd auth doctor` prints a JSON envelope (`data`) with:
+
+- `sections[]` — Environment, Storage, Profiles, Credentials, optional Network, Runtime  
+- `summary` — counts of ok / info / warn / fail  
+- `recommendations[]`  
+- `activeProfile`
+
+Useful flags:
+
+```bash
+gpd auth doctor --refresh-check
+gpd auth doctor --refresh-check --network --package com.example.app
+gpd auth diagnose --refresh-check   # alias
+```
+
+`gpd config doctor` remains available for config-path and store-tokens issues; prefer **auth doctor** for credential health.
+
+## Migration guidance for ASC users
+
+### Service-account first (recommended)
+
+1. Create a Google Cloud service account.  
+2. Enable Android Publisher API (and other APIs you need).  
+3. Invite the service account in Play Console with the right app permissions.  
+4. ```bash
+   gpd auth login ci --key-path ./sa.json
+   gpd auth status
+   gpd auth check --package com.example.app
+   ```
+
+### Profile hygiene
+
+```bash
+gpd auth list
+gpd auth switch ci
+gpd auth status --pretty
+gpd auth logout --name staging      # clear one profile's stored tokens
+gpd auth logout --all               # clear every profile
+gpd auth delete staging             # remove a non-active profile
+gpd auth delete ci --force          # delete active profile; switches to default
+```
+
+### Diagnostics before filing bugs
+
+```bash
+gpd auth doctor --refresh-check --output json --pretty
+gpd config doctor --pretty
+```
+
+## Known boundaries
+
+- No ASC-identical `.p8` / issuer workflow — different platforms.  
+- No browser redirect login for Play automation.  
+- `auth logout` clears stored tokens/metadata for the active profile (or `--name` / `--all`); `auth delete` removes a named profile and refuses the active profile unless `--force`.  
+- OAuth device flow depends on `GPD_CLIENT_ID` (and optional secret) being configured.  
+- Testing-mode OAuth apps: refresh tokens can expire after 7 days.
+
+## Related
+
+- [ASC Parity Matrix](asc-parity.md)  
+- [ASC Workflow Mapping](asc-workflow-mapping.md)  
+- Multi-account implementation notes: [PLAN-multi-account.md](PLAN-multi-account.md)

--- a/docs/development/CLI_STRUCTURE.md
+++ b/docs/development/CLI_STRUCTURE.md
@@ -1,0 +1,134 @@
+# CLI Structure (Kong + domain packages)
+
+This document describes how the gpd CLI is organized today and the incremental plan for moving toward domain packages under `internal/cli/<domain>/`.
+
+## Current Kong layout
+
+Entry point: `cmd/gpd` → `cli.RunKongCLI()` in [`internal/cli/kong_cli.go`](../../internal/cli/kong_cli.go).
+
+| Layer | Location | Role |
+|-------|----------|------|
+| Root + globals | `kong_cli.go` | `KongCLI`, `Globals`, parser setup, profile/output resolution, command execution |
+| Command groups | `kong_*.go` | Nested Kong command structs (`AuthCmd`, `PublishCmd`, …) and `Run` methods |
+| Shared helpers | `kong_helpers.go`, `pagination.go`, `progress.go`, … | Cross-command utilities still in package `cli` |
+| Domain packages | `internal/cli/<domain>/` | Extracted pure helpers / focused subsystems (growing) |
+
+### Registration model
+
+- Command **types and handlers** live in `kong_<group>.go` files in package `cli`.
+- Command **registration** is declarative: fields on `KongCLI` in `kong_cli.go` (Kong struct tags).
+- Global flags (`--package`, `--output`, `--profile`, …) live on `Globals` and are injected into every `Run(globals *Globals)`.
+
+Example shape:
+
+```go
+// kong_cli.go
+type KongCLI struct {
+    Globals
+    Auth    AuthCmd    `cmd:"" help:"Authentication commands"`
+    Publish PublishCmd `cmd:"" help:"Publishing commands"`
+    // ...
+}
+
+// kong_auth.go (same package cli)
+type AuthCmd struct {
+    Status AuthStatusCmd `cmd:"" help:"Check authentication status"`
+}
+```
+
+There is no separate “register commands” function; adding a top-level command means adding a field on `KongCLI` and implementing the nested types’ `Run` methods.
+
+## Rule: new command families use domain packages
+
+**Prefer this for new work:**
+
+1. Put pure logic, plans, and non-Kong helpers in `internal/cli/<domain>/` (own package name, e.g. `outfmt`, `playship`).
+2. Keep thin Kong adapter types in `internal/cli/kong_<domain>.go` (or extend an existing `kong_*.go`) that call into the domain package.
+3. Register the command group on `KongCLI` in `kong_cli.go` only when introducing a new top-level command.
+
+### Reference extraction: `outfmt`
+
+TTY-aware default output resolution was moved out of package `cli` as a low-churn example:
+
+- Package: [`internal/cli/outfmt`](../../internal/cli/outfmt)
+- API: `ResolveOutputFromEnvAndTTY`, `ResolveDefaultOutput`, `OutputFlagSet`, `EnvDefaultOutput`
+- Caller: `RunKongCLI` in `kong_cli.go` imports `outfmt` and sets `cli.Output`
+
+Behavior is unchanged: explicit `--output` > `GPD_DEFAULT_OUTPUT` > `table` on TTY / `json` in pipes/CI.
+
+### What stays in package `cli` (for now)
+
+- Large existing groups (`kong_publish.go`, `kong_auth.go`, `kong_validate.go`, …)
+- Types that embed Kong tags and need access to unexported package helpers
+- Cross-cutting wiring (auth globals, extension help, update checks)
+
+Do **not** rewrite multi-thousand-line files in one pass. Extract pure helpers first; move command structs later if needed.
+
+## Migration plan (auth / publish over time)
+
+Full split is **incremental**. Suggested order:
+
+### Phase 0 — Pattern established (this doc + `outfmt`)
+
+- Domain package layout documented.
+- One real extraction (`outfmt`) proves import/test patterns.
+
+### Phase 1 — Pure helpers from publish / play (done for playship)
+
+Package [`internal/cli/playship`](../../internal/cli/playship):
+
+- `ResolveReleaseParams`, `BuildTrackRelease`, `BuildPlan`
+- Kong adapter: `PublishPlayCmd` in `kong_publish.go` calls `playship.*`
+
+Further candidates when touch risk is low:
+- `buildPlayTrackRelease`
+- `buildPublishPlayPlan`
+
+Target package name (suggested): `internal/cli/playship/` (or `play`).
+
+Constraints:
+
+- Keep unit tests green (`go test -tags=unit ./internal/cli/...`).
+- Prefer moving pure functions first; leave `Run` methods in `kong_publish.go`.
+- Avoid simultaneous large edits to `kong_auth.go` / `kong_validate.go` when those files are under concurrent work.
+
+### Phase 2 — Auth domain package
+
+- Extract non-UI auth helpers (profile resolution wiring already leans on `internal/config` and `internal/auth`).
+- Leave Kong command structs in `kong_auth.go` until helpers are stable.
+- `internal/auth` remains the credential/token subsystem; CLI domain packages only adapt CLI concerns.
+
+### Phase 3 — Optional command-struct relocation
+
+Only if package `cli` remains hard to navigate:
+
+- Move selected `*Cmd` types into domain packages **if** Kong + globals injection stays clean.
+- Re-export or thin-wrap in `kong_cli.go` / `kong_*.go` as needed.
+- No user-facing flag or subcommand path changes.
+
+## Testing expectations
+
+```bash
+# Package-scoped unit tests (preferred for domain packages)
+go test -tags=unit ./internal/cli/outfmt/...
+
+# Full CLI unit suite after extractions
+go test -tags=unit ./internal/cli/...
+```
+
+Domain package tests should use `//go:build unit` consistently with existing CLI tests.
+
+## Conflict-minimization guidelines
+
+| Do | Don’t |
+|----|--------|
+| Extract small, pure helpers into new packages | Rewrite all of `kong_publish.go` in one PR |
+| Update only direct callers of moved symbols | Drive-by renames across auth/validate |
+| Add docs for the pattern when establishing it | Duplicate env/format constants in many places without reason |
+| Keep user-facing CLI behavior identical | Change flag defaults or help text as a side effect of moves |
+
+## Related docs
+
+- [KONG_MIGRATION.md](../KONG_MIGRATION.md) — original Cobra → Kong migration notes
+- [AGENTS.md](./AGENTS.md) — agent-oriented project guide
+- [COMMANDS.md](../COMMANDS.md) — generated/command reference

--- a/docs/examples/ci-cd-integration.md
+++ b/docs/examples/ci-cd-integration.md
@@ -6,11 +6,12 @@ This guide demonstrates how to integrate the Google Play Developer CLI (`gpd`) i
 
 1. [Overview](#overview)
 2. [Authentication Setup](#authentication-setup)
-3. [GitHub Actions Examples](#github-actions-examples)
-4. [GitLab CI Examples](#gitlab-ci-examples)
-5. [Common Patterns](#common-patterns)
-6. [Best Practices](#best-practices)
-7. [Troubleshooting](#troubleshooting)
+3. [Install gpd in CI (`setup-gpd`)](#install-gpd-in-ci-setup-gpd)
+4. [GitHub Actions Examples](#github-actions-examples)
+5. [GitLab CI Examples](#gitlab-ci-examples)
+6. [Common Patterns](#common-patterns)
+7. [Best Practices](#best-practices)
+8. [Troubleshooting](#troubleshooting)
 
 ## Overview
 
@@ -139,6 +140,67 @@ For environments where you can securely store files:
 
 4. **Application Default Credentials**: For GCP environments
 
+## Install gpd in CI (`setup-gpd`)
+
+Prefer the official composite action over piping `install.sh` in GitHub Actions. It resolves a release tag, downloads the correct OS/arch asset, verifies checksums when present, adds the binary to `PATH`, and runs `gpd version`.
+
+### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | Release tag or version (`latest`, `v0.6.4`, or `0.6.4`) |
+| `token` | `github.token` | Optional GitHub token to avoid API rate limits when resolving releases |
+
+### Minimal example
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup gpd
+        uses: dl-alexandre/Google-Play-Developer-CLI/.github/actions/setup-gpd@main
+        with:
+          # Pin binary version in CI (prefer explicit tags over latest).
+          version: v0.6.4
+          # Optional: raise API rate limits (defaults to github.token)
+          # token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify install
+        run: gpd version
+
+      - name: Deploy
+        env:
+          GPD_SERVICE_ACCOUNT_KEY: ${{ secrets.GPD_SERVICE_ACCOUNT_KEY }}
+        run: |
+          gpd publish upload app-release.aab \
+            --package ${{ secrets.APP_PACKAGE_NAME }} \
+            --track internal
+```
+
+### Local path (this repository)
+
+When the workflow lives in the gpd repo itself:
+
+```yaml
+- uses: ./.github/actions/setup-gpd
+  with:
+    version: v0.6.4
+```
+
+### Alternative: install script
+
+If you are not using GitHub Actions (or cannot use composite actions), the install script still works:
+
+```yaml
+- name: Install gpd
+  run: |
+    curl -fsSL https://raw.githubusercontent.com/dl-alexandre/Google-Play-Developer-CLI/main/install.sh | bash
+    echo "$HOME/.local/bin" >> $GITHUB_PATH
+```
+
 ## GitHub Actions Examples
 
 ### Basic Upload Workflow
@@ -174,15 +236,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22.x'
-
-      - name: Install gpd
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/dl-alexandre/Google-Play-Developer-CLI/main/install.sh | bash
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Setup gpd
+        uses: dl-alexandre/Google-Play-Developer-CLI/.github/actions/setup-gpd@main
 
       - name: Verify authentication
         env:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/xuri/excelize/v2 v2.10.1
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 	google.golang.org/api v0.286.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -49,7 +50,6 @@ require (
 	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 	google.golang.org/genproto v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad // indirect

--- a/install.sh
+++ b/install.sh
@@ -1,57 +1,209 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+# install.sh — install gpd with mandatory release checksum verification.
+#
+# Environment:
+#   INSTALL_DIR              install destination (default: ~/.local/bin or /usr/local/bin)
+#   GPD_INSTALL_INSECURE=1   allow install when checksum verification cannot run
+#   GPD_INSTALL_ASSET        (test) path to a local release asset instead of downloading
+#   GPD_INSTALL_CHECKSUMS    (test) path to a local checksums file
+#   GPD_INSTALL_SKIP_EXTRACT=1 (test) treat asset as the binary itself (no tar)
+set -euo pipefail
 
-REPO="dl-alexandre/Google-Play-Developer-CLI"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+REPO="${GPD_INSTALL_REPO:-dl-alexandre/Google-Play-Developer-CLI}"
+BIN_NAME="gpd"
+DEFAULT_INSTALL_DIR="/usr/local/bin"
+if [ -n "${HOME:-}" ]; then
+  DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+fi
+INSTALL_DIR="${INSTALL_DIR:-${DEFAULT_INSTALL_DIR}}"
+DOWNLOAD_MAX_ATTEMPTS=3
+DOWNLOAD_RETRY_DELAY_SECONDS=1
 
-# Detect OS and architecture
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
+curl_with_retry() {
+  local attempt=1
+  while true; do
+    if curl -fsSL "$@"; then
+      return 0
+    fi
+    if [ "${attempt}" -ge "${DOWNLOAD_MAX_ATTEMPTS}" ]; then
+      return 1
+    fi
+    attempt=$((attempt + 1))
+    echo "Download failed; retrying (${attempt}/${DOWNLOAD_MAX_ATTEMPTS})..." >&2
+    sleep "${DOWNLOAD_RETRY_DELAY_SECONDS}"
+  done
+}
 
-case "$ARCH" in
-  x86_64) ARCH="x86_64" ;;
-  amd64) ARCH="x86_64" ;;
-  arm64) ARCH="arm64" ;;
-  aarch64) ARCH="arm64" ;;
-  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+# verification_unavailable aborts unless GPD_INSTALL_INSECURE=1.
+verification_unavailable() {
+  local reason="$1"
+  if [ "${GPD_INSTALL_INSECURE:-}" = "1" ]; then
+    echo "!!! WARNING: ${reason}" >&2
+    echo "!!! GPD_INSTALL_INSECURE=1 is set; installing WITHOUT checksum verification." >&2
+    return 0
+  fi
+  echo "Error: ${reason}" >&2
+  echo "Refusing to install without SHA-256 checksum verification." >&2
+  echo "If you understand the risk and must install anyway, re-run with GPD_INSTALL_INSECURE=1." >&2
+  exit 1
+}
+
+# verify_checksum ASSET_PATH CHECKSUMS_PATH ASSET_NAME
+# Returns 0 on match, 1 on mismatch / missing entry. Exits 1 on hard failure
+# when not insecure.
+verify_checksum() {
+  local asset_path="$1"
+  local checksums_path="$2"
+  local asset_name="$3"
+
+  if [ ! -f "${checksums_path}" ]; then
+    verification_unavailable "Checksums file not found: ${checksums_path}"
+    return 0
+  fi
+
+  local expected
+  expected="$(awk -v asset="${asset_name}" '$2 == asset || $2 == "*" asset { print $1; exit }' "${checksums_path}")"
+  if [ -z "${expected}" ]; then
+    verification_unavailable "Asset ${asset_name} not found in checksums file."
+    return 0
+  fi
+
+  local actual=""
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "${asset_path}" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "${asset_path}" | awk '{print $1}')"
+  else
+    verification_unavailable "No checksum tool (shasum/sha256sum) available."
+    return 0
+  fi
+
+  if [ "${expected}" != "${actual}" ]; then
+    echo "Error: Checksum verification failed for ${asset_name}." >&2
+    echo "  expected: ${expected}" >&2
+    echo "  actual:   ${actual}" >&2
+    return 1
+  fi
+
+  echo "Checksum verified for ${asset_name}"
+  return 0
+}
+
+# Allow sourcing for unit tests without running install.
+if [ "${GPD_INSTALL_LIB_ONLY:-}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+
+case "${ARCH}" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: ${ARCH}" >&2
+    exit 1
+    ;;
 esac
 
-case "$OS" in
+case "${OS}" in
   darwin) OS="darwin" ;;
   linux) OS="linux" ;;
-  *) echo "Unsupported OS: $OS"; exit 1 ;;
+  *)
+    echo "Unsupported OS: ${OS}" >&2
+    exit 1
+    ;;
 esac
 
-# Get latest release
-LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-VERSION="${LATEST#v}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
 
-if [ -z "$VERSION" ]; then
-  echo "Failed to get latest version"
+if [ -n "${GPD_INSTALL_ASSET:-}" ]; then
+  # Test / offline path: local fixture asset.
+  ASSET_PATH="${GPD_INSTALL_ASSET}"
+  ASSET_NAME="$(basename "${ASSET_PATH}")"
+  if [ ! -f "${ASSET_PATH}" ]; then
+    echo "Error: GPD_INSTALL_ASSET not found: ${ASSET_PATH}" >&2
+    exit 1
+  fi
+  cp "${ASSET_PATH}" "${TMP_DIR}/${ASSET_NAME}"
+  ASSET_PATH="${TMP_DIR}/${ASSET_NAME}"
+
+  if [ -n "${GPD_INSTALL_CHECKSUMS:-}" ]; then
+    CHECKSUMS_PATH="${GPD_INSTALL_CHECKSUMS}"
+  else
+    verification_unavailable "GPD_INSTALL_ASSET set without GPD_INSTALL_CHECKSUMS."
+    CHECKSUMS_PATH=""
+  fi
+
+  if [ -n "${CHECKSUMS_PATH}" ]; then
+    if ! verify_checksum "${ASSET_PATH}" "${CHECKSUMS_PATH}" "${ASSET_NAME}"; then
+      exit 1
+    fi
+  fi
+
+  if [ "${GPD_INSTALL_SKIP_EXTRACT:-}" = "1" ]; then
+    BIN_SRC="${ASSET_PATH}"
+  else
+    tar -xzf "${ASSET_PATH}" -C "${TMP_DIR}"
+    BIN_SRC="${TMP_DIR}/${BIN_NAME}"
+  fi
+else
+  # Production path: download latest release.
+  LATEST="$(curl_with_retry "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+  VERSION="${LATEST#v}"
+  if [ -z "${VERSION}" ]; then
+    echo "Failed to get latest version" >&2
+    exit 1
+  fi
+
+  echo "Installing gpd ${LATEST}..."
+
+  FILENAME="gpd_${VERSION}_${OS}_${ARCH}.tar.gz"
+  BASE_URL="https://github.com/${REPO}/releases/download/${LATEST}"
+  BIN_URL="${BASE_URL}/${FILENAME}"
+  CHECKSUMS_ASSET="checksums.txt"
+  # Prefer gpd_*_checksums.txt if present; fall back to checksums.txt
+  CHECKSUMS_URL="${BASE_URL}/gpd_${VERSION}_checksums.txt"
+  CHECKSUMS_URL_ALT="${BASE_URL}/checksums.txt"
+
+  curl_with_retry "${BIN_URL}" -o "${TMP_DIR}/${FILENAME}"
+
+  CHECKSUMS_PATH="${TMP_DIR}/checksums.txt"
+  if curl_with_retry "${CHECKSUMS_URL}" -o "${CHECKSUMS_PATH}"; then
+    :
+  elif curl_with_retry "${CHECKSUMS_URL_ALT}" -o "${CHECKSUMS_PATH}"; then
+    :
+  else
+    verification_unavailable "Could not download checksums from release ${LATEST}."
+    CHECKSUMS_PATH=""
+  fi
+
+  if [ -n "${CHECKSUMS_PATH}" ] && [ -f "${CHECKSUMS_PATH}" ]; then
+    if ! verify_checksum "${TMP_DIR}/${FILENAME}" "${CHECKSUMS_PATH}" "${FILENAME}"; then
+      exit 1
+    fi
+  fi
+
+  tar -xzf "${TMP_DIR}/${FILENAME}" -C "${TMP_DIR}"
+  BIN_SRC="${TMP_DIR}/${BIN_NAME}"
+fi
+
+if [ ! -f "${BIN_SRC}" ]; then
+  echo "Error: binary not found after extract: ${BIN_SRC}" >&2
   exit 1
 fi
 
-echo "Installing gpd ${LATEST}..."
-
-# Download and extract
-FILENAME="gpd_${VERSION}_${OS}_${ARCH}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${LATEST}/${FILENAME}"
-
-TMP_DIR=$(mktemp -d)
-trap "rm -rf $TMP_DIR" EXIT
-
-curl -fsSL "$URL" -o "$TMP_DIR/$FILENAME"
-tar -xzf "$TMP_DIR/$FILENAME" -C "$TMP_DIR"
-
-# Install
-if [ -w "$INSTALL_DIR" ]; then
-  mv "$TMP_DIR/gpd" "$INSTALL_DIR/gpd"
+mkdir -p "${INSTALL_DIR}"
+if [ -w "${INSTALL_DIR}" ]; then
+  mv "${BIN_SRC}" "${INSTALL_DIR}/${BIN_NAME}"
 else
-  echo "Installing to $INSTALL_DIR (requires sudo)..."
-  sudo mv "$TMP_DIR/gpd" "$INSTALL_DIR/gpd"
+  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo mv "${BIN_SRC}" "${INSTALL_DIR}/${BIN_NAME}"
 fi
 
-chmod +x "$INSTALL_DIR/gpd"
-
-echo "gpd installed to $INSTALL_DIR/gpd"
-"$INSTALL_DIR/gpd" version
+chmod +x "${INSTALL_DIR}/${BIN_NAME}"
+echo "gpd installed to ${INSTALL_DIR}/${BIN_NAME}"
+if [ "${GPD_INSTALL_SKIP_VERSION:-}" != "1" ]; then
+  "${INSTALL_DIR}/${BIN_NAME}" version || true
+fi

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -476,11 +476,13 @@ type CheckResult struct {
 // Status represents the current authentication status.
 type Status struct {
 	Authenticated bool   `json:"authenticated"`
+	Profile       string `json:"profile,omitempty"`
 	Origin        string `json:"origin,omitempty"`
 	Email         string `json:"email,omitempty"`
 	KeyPath       string `json:"keyPath,omitempty"`
 	TokenValid    bool   `json:"tokenValid"`
 	TokenExpiry   string `json:"tokenExpiry,omitempty"`
+	TokenLocation string `json:"tokenLocation,omitempty"`
 }
 
 // GetStatus returns the current authentication status.
@@ -488,17 +490,26 @@ func (m *Manager) GetStatus(ctx context.Context) (*Status, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	profile := m.activeProfile
+	if profile == "" {
+		profile = defaultAuthProfile
+	}
+
 	if m.creds == nil {
 		return &Status{
 			Authenticated: false,
+			Profile:       profile,
+			TokenLocation: m.TokenLocation(),
 		}, nil
 	}
 
 	status := &Status{
 		Authenticated: true,
+		Profile:       profile,
 		Origin:        m.creds.Origin.String(),
 		Email:         m.creds.Email,
 		KeyPath:       m.creds.KeyPath,
+		TokenLocation: m.TokenLocation(),
 	}
 
 	// Check token validity

--- a/internal/auth/token_storage.go
+++ b/internal/auth/token_storage.go
@@ -225,3 +225,183 @@ func (m *Manager) loadStoredToken(key string) (*oauth2.Token, error) {
 	}
 	return token, nil
 }
+
+// normalizeProfile returns a non-empty profile name, defaulting to "default".
+func normalizeProfile(profile string) string {
+	profile = strings.TrimSpace(profile)
+	if profile == "" {
+		return defaultAuthProfile
+	}
+	return profile
+}
+
+// collectProfileTokenKeys returns all storage keys that belong to profile,
+// based on token metadata files under the config tokens directory.
+func collectProfileTokenKeys(profile string) ([]string, error) {
+	profile = normalizeProfile(profile)
+	paths := config.GetPaths()
+	dir := filepath.Join(paths.ConfigDir, "tokens")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	var keys []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), tokenMetadataSuffix) {
+			continue
+		}
+		metaPath := filepath.Join(dir, entry.Name())
+		meta, err := readTokenMetadata(metaPath)
+		if err != nil || meta == nil {
+			continue
+		}
+		if meta.Profile != profile {
+			continue
+		}
+		key := strings.TrimSuffix(entry.Name(), tokenMetadataSuffix)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// collectAllTokenKeys returns every storage key that has a metadata file.
+func collectAllTokenKeys() ([]string, error) {
+	paths := config.GetPaths()
+	dir := filepath.Join(paths.ConfigDir, "tokens")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var keys []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), tokenMetadataSuffix) {
+			continue
+		}
+		key := strings.TrimSuffix(entry.Name(), tokenMetadataSuffix)
+		if key == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// deleteTokenKey removes a token from secure storage (best-effort) and deletes
+// its metadata file if present.
+func (m *Manager) deleteTokenKey(key string) error {
+	if key == "" {
+		return nil
+	}
+	if m.storage != nil && m.storage.Available() {
+		// Best-effort: missing keys are not fatal during cleanup.
+		_ = m.storage.Delete(key)
+	}
+	metaPath := tokenMetadataPath(key)
+	if err := os.Remove(metaPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// ClearProfile removes stored tokens and metadata for the given profile.
+// If the profile is the manager's active profile, in-memory credentials are cleared.
+// Succeeds even when no stored data exists for the profile.
+func (m *Manager) ClearProfile(profile string) error {
+	profile = normalizeProfile(profile)
+	keys, err := collectProfileTokenKeys(profile)
+	if err != nil {
+		return err
+	}
+	// Always attempt the bare profile key (used when client ID hash is empty).
+	bare := tokenStorageKey(profile, "")
+	hasBare := false
+	for _, k := range keys {
+		if k == bare {
+			hasBare = true
+			break
+		}
+	}
+	if !hasBare {
+		keys = append(keys, bare)
+	}
+
+	for _, key := range keys {
+		if err := m.deleteTokenKey(key); err != nil {
+			return err
+		}
+	}
+
+	if m.GetActiveProfile() == profile {
+		m.Clear()
+	}
+	return nil
+}
+
+// ClearAllProfiles removes tokens and metadata for every stored profile and
+// clears in-memory credentials.
+func (m *Manager) ClearAllProfiles() error {
+	keys, err := collectAllTokenKeys()
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		if err := m.deleteTokenKey(key); err != nil {
+			return err
+		}
+	}
+	m.Clear()
+	return nil
+}
+
+// DeleteProfile removes a profile's stored credentials and metadata.
+// Returns false for existed when no metadata was found for the profile.
+// Unlike ClearProfile, callers use existed to report "not found".
+func (m *Manager) DeleteProfile(profile string) (existed bool, err error) {
+	profile = normalizeProfile(profile)
+	keys, err := collectProfileTokenKeys(profile)
+	if err != nil {
+		return false, err
+	}
+	if len(keys) == 0 {
+		// Also treat bare secure-storage entry without metadata as existing.
+		if m.storage != nil && m.storage.Available() {
+			if data, retrieveErr := m.storage.Retrieve(tokenStorageKey(profile, "")); retrieveErr == nil && len(data) > 0 {
+				if clearErr := m.ClearProfile(profile); clearErr != nil {
+					return true, clearErr
+				}
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	if err := m.ClearProfile(profile); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+// ProfileExists reports whether any token metadata is stored for profile.
+func (m *Manager) ProfileExists(profile string) (bool, error) {
+	profile = normalizeProfile(profile)
+	keys, err := collectProfileTokenKeys(profile)
+	if err != nil {
+		return false, err
+	}
+	return len(keys) > 0, nil
+}

--- a/internal/auth/token_storage_test.go
+++ b/internal/auth/token_storage_test.go
@@ -427,3 +427,241 @@ func TestLoadStoredTokenExpiredNoRefresh(t *testing.T) {
 		t.Fatalf("expected nil for expired token without refresh token")
 	}
 }
+
+func TestClearProfileRemovesMetadataAndStorage(t *testing.T) {
+	tempHome := t.TempDir()
+	setConfigEnv(t, tempHome)
+
+	storage := &memoryStorage{available: true}
+	m := NewManager(storage)
+	m.SetStoreTokens("auto")
+	m.SetActiveProfile("team-a")
+
+	key := tokenStorageKey("team-a", "hash1")
+	meta := &TokenMetadata{
+		Profile:      "team-a",
+		ClientIDHash: "hash1",
+		Origin:       "keyfile",
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := writeTokenMetadata(key, meta); err != nil {
+		t.Fatalf("writeTokenMetadata error: %v", err)
+	}
+	if err := storage.Store(key, []byte(`{"access_token":"tok"}`)); err != nil {
+		t.Fatalf("store error: %v", err)
+	}
+	// Leave an unrelated profile intact.
+	otherKey := tokenStorageKey("team-b", "hash2")
+	otherMeta := &TokenMetadata{
+		Profile:      "team-b",
+		ClientIDHash: "hash2",
+		Origin:       "oauth",
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := writeTokenMetadata(otherKey, otherMeta); err != nil {
+		t.Fatalf("writeTokenMetadata other error: %v", err)
+	}
+	if err := storage.Store(otherKey, []byte(`{"access_token":"other"}`)); err != nil {
+		t.Fatalf("store other error: %v", err)
+	}
+
+	// Seed in-memory creds so Clear() can be observed.
+	m.mu.Lock()
+	m.creds = &Credentials{Email: "a@example.com"}
+	m.mu.Unlock()
+
+	if err := m.ClearProfile("team-a"); err != nil {
+		t.Fatalf("ClearProfile error: %v", err)
+	}
+
+	if _, err := os.Stat(tokenMetadataPath(key)); !os.IsNotExist(err) {
+		t.Fatalf("expected team-a metadata removed, stat err=%v", err)
+	}
+	if _, err := storage.Retrieve(key); err == nil {
+		t.Fatal("expected team-a storage key removed")
+	}
+	if m.GetCredentials() != nil {
+		t.Fatal("expected in-memory creds cleared for active profile")
+	}
+
+	// Other profile preserved.
+	if _, err := os.Stat(tokenMetadataPath(otherKey)); err != nil {
+		t.Fatalf("expected team-b metadata kept: %v", err)
+	}
+	if _, err := storage.Retrieve(otherKey); err != nil {
+		t.Fatalf("expected team-b storage kept: %v", err)
+	}
+}
+
+func TestClearProfileNonActiveKeepsInMemory(t *testing.T) {
+	tempHome := t.TempDir()
+	setConfigEnv(t, tempHome)
+
+	storage := &memoryStorage{available: true}
+	m := NewManager(storage)
+	m.SetActiveProfile("active")
+	m.mu.Lock()
+	m.creds = &Credentials{Email: "active@example.com"}
+	m.mu.Unlock()
+
+	meta := &TokenMetadata{
+		Profile:      "other",
+		ClientIDHash: "h",
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := writeTokenMetadata("other--h", meta); err != nil {
+		t.Fatalf("writeTokenMetadata error: %v", err)
+	}
+
+	if err := m.ClearProfile("other"); err != nil {
+		t.Fatalf("ClearProfile error: %v", err)
+	}
+	if m.GetCredentials() == nil || m.GetCredentials().Email != "active@example.com" {
+		t.Fatal("clearing non-active profile must not wipe in-memory active creds")
+	}
+}
+
+func TestClearAllProfiles(t *testing.T) {
+	tempHome := t.TempDir()
+	setConfigEnv(t, tempHome)
+
+	storage := &memoryStorage{available: true}
+	m := NewManager(storage)
+	m.SetStoreTokens("auto")
+
+	for _, p := range []string{"a", "b"} {
+		key := tokenStorageKey(p, "h")
+		if err := writeTokenMetadata(key, &TokenMetadata{
+			Profile: p, ClientIDHash: "h", UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		}); err != nil {
+			t.Fatalf("write meta %s: %v", p, err)
+		}
+		if err := storage.Store(key, []byte(`{"access_token":"t"}`)); err != nil {
+			t.Fatalf("store %s: %v", p, err)
+		}
+	}
+	m.mu.Lock()
+	m.creds = &Credentials{Email: "x@example.com"}
+	m.mu.Unlock()
+
+	if err := m.ClearAllProfiles(); err != nil {
+		t.Fatalf("ClearAllProfiles error: %v", err)
+	}
+	profiles, err := m.ListProfiles()
+	if err != nil {
+		t.Fatalf("ListProfiles error: %v", err)
+	}
+	if len(profiles) != 0 {
+		t.Fatalf("expected no profiles, got %d", len(profiles))
+	}
+	if m.GetCredentials() != nil {
+		t.Fatal("expected in-memory cleared")
+	}
+}
+
+func TestDeleteProfile(t *testing.T) {
+	tempHome := t.TempDir()
+	setConfigEnv(t, tempHome)
+
+	storage := &memoryStorage{available: true}
+	m := NewManager(storage)
+
+	existed, err := m.DeleteProfile("missing")
+	if err != nil {
+		t.Fatalf("DeleteProfile missing error: %v", err)
+	}
+	if existed {
+		t.Fatal("expected existed=false for missing profile")
+	}
+
+	key := tokenStorageKey("prod", "abc")
+	if err := writeTokenMetadata(key, &TokenMetadata{
+		Profile: "prod", ClientIDHash: "abc", UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeTokenMetadata: %v", err)
+	}
+	if err := storage.Store(key, []byte(`{"access_token":"t"}`)); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	existed, err = m.DeleteProfile("prod")
+	if err != nil {
+		t.Fatalf("DeleteProfile error: %v", err)
+	}
+	if !existed {
+		t.Fatal("expected existed=true")
+	}
+	ok, err := m.ProfileExists("prod")
+	if err != nil {
+		t.Fatalf("ProfileExists error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected profile gone")
+	}
+}
+
+func TestDeleteProfileBareStorageOnly(t *testing.T) {
+	tempHome := t.TempDir()
+	setConfigEnv(t, tempHome)
+
+	storage := &memoryStorage{available: true}
+	m := NewManager(storage)
+	// Profile key with no metadata file.
+	if err := storage.Store("solo", []byte(`{"access_token":"t"}`)); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	existed, err := m.DeleteProfile("solo")
+	if err != nil {
+		t.Fatalf("DeleteProfile error: %v", err)
+	}
+	if !existed {
+		t.Fatal("expected bare storage key to count as existing")
+	}
+	if _, err := storage.Retrieve("solo"); err == nil {
+		t.Fatal("expected bare key deleted")
+	}
+}
+
+func TestProfileExistsAndCollectKeys(t *testing.T) {
+	tempHome := t.TempDir()
+	setConfigEnv(t, tempHome)
+
+	m := NewManager(&memoryStorage{available: true})
+	ok, err := m.ProfileExists("none")
+	if err != nil || ok {
+		t.Fatalf("expected false, got %v %v", ok, err)
+	}
+
+	if err := writeTokenMetadata("p--h1", &TokenMetadata{
+		Profile: "p", ClientIDHash: "h1", UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := writeTokenMetadata("p--h2", &TokenMetadata{
+		Profile: "p", ClientIDHash: "h2", UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	keys, err := collectProfileTokenKeys("p")
+	if err != nil {
+		t.Fatalf("collectProfileTokenKeys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %v", keys)
+	}
+	ok, err = m.ProfileExists("p")
+	if err != nil || !ok {
+		t.Fatalf("expected exists, got %v %v", ok, err)
+	}
+}
+
+func TestClearProfileMissingIsOK(t *testing.T) {
+	tempHome := t.TempDir()
+	setConfigEnv(t, tempHome)
+	m := NewManager(&memoryStorage{available: true})
+	if err := m.ClearProfile("ghost"); err != nil {
+		t.Fatalf("ClearProfile empty should succeed: %v", err)
+	}
+}

--- a/internal/cli/kong_auth.go
+++ b/internal/cli/kong_auth.go
@@ -3,15 +3,33 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
 
+	"google.golang.org/api/androidpublisher/v3"
+
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/api"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/auth"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/config"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/errors"
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/output"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/storage"
 )
 
 // AuthCmd contains authentication commands.
 type AuthCmd struct {
-	Status AuthStatusCmd `cmd:"" help:"Check authentication status"`
-	Login  AuthLoginCmd  `cmd:"" help:"Authenticate with Google Play"`
-	Logout AuthLogoutCmd `cmd:"" help:"Sign out and clear credentials"`
+	Status   AuthStatusCmd   `cmd:"" help:"Check authentication status"`
+	Login    AuthLoginCmd    `cmd:"" help:"Authenticate with Google Play"`
+	Init     AuthInitCmd     `cmd:"" help:"Initialize auth for a profile (alias of login)"`
+	Logout   AuthLogoutCmd   `cmd:"" help:"Sign out and clear stored credentials for a profile"`
+	Delete   AuthDeleteCmd   `cmd:"" help:"Delete a stored authentication profile"`
+	List     AuthListCmd     `cmd:"" help:"List stored authentication profiles"`
+	Switch   AuthSwitchCmd   `cmd:"" help:"Switch the active authentication profile"`
+	Check    AuthCheckCmd    `cmd:"" help:"Validate package permissions for current credentials"`
+	Doctor   AuthDoctorCmd   `cmd:"" help:"Diagnose authentication setup"`
+	Diagnose AuthDiagnoseCmd `cmd:"" help:"Detailed auth diagnostics (alias of doctor)"`
 }
 
 // AuthStatusCmd checks authentication status.
@@ -19,12 +37,12 @@ type AuthStatusCmd struct{}
 
 // Run executes the auth status command.
 func (cmd *AuthStatusCmd) Run(globals *Globals) error {
-	ctx := context.Background()
+	ctx := authContext(globals)
 	authMgr := newAuthManager()
 
 	// Try to authenticate with empty key path to load existing credentials
 	// from storage, environment, or ADC
-	_, _ = authMgr.Authenticate(ctx, "")
+	_, _ = authMgr.Authenticate(ctx, globals.KeyPath)
 
 	status, err := authMgr.GetStatus(ctx)
 	if err != nil {
@@ -37,31 +55,648 @@ func (cmd *AuthStatusCmd) Run(globals *Globals) error {
 
 // AuthLoginCmd authenticates with Google Play.
 type AuthLoginCmd struct {
-	Key string `help:"Path to service account key file" type:"existingfile"`
+	Profile string `arg:"" optional:"" help:"Profile name to store credentials under"`
+	Key     string `help:"Path to service account key file" type:"existingfile"`
 }
 
 // Run executes the auth login command.
 func (cmd *AuthLoginCmd) Run(globals *Globals) error {
-	ctx := context.Background()
+	return runAuthLogin(globals, cmd.Profile, cmd.Key)
+}
+
+// AuthInitCmd is an ASC-parity alias for login with an optional profile.
+type AuthInitCmd struct {
+	Profile string `arg:"" optional:"" help:"Profile name to initialize"`
+	Key     string `help:"Path to service account key file" type:"existingfile"`
+}
+
+// Run executes the auth init command.
+func (cmd *AuthInitCmd) Run(globals *Globals) error {
+	return runAuthLogin(globals, cmd.Profile, cmd.Key)
+}
+
+func runAuthLogin(globals *Globals, profileArg, keyPath string) error {
+	ctx := authContext(globals)
 	authMgr := newAuthManager()
 
-	_, err := authMgr.Authenticate(ctx, cmd.Key)
+	profile := strings.TrimSpace(profileArg)
+	if profile == "" {
+		profile = strings.TrimSpace(globals.Profile)
+	}
+	if profile == "" {
+		profile = "default"
+	}
+	authMgr.SetActiveProfile(profile)
+
+	if keyPath == "" {
+		keyPath = globals.KeyPath
+	}
+
+	creds, err := authMgr.Authenticate(ctx, keyPath)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("Authentication successful")
-	return nil
+	if err := config.SetActiveProfile(profile); err != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("authenticated but failed to persist active profile: %v", err)).
+			WithHint("Credentials may still work for this process; check config write permissions")
+	}
+	globals.Profile = profile
+	applyAuthGlobals(globals)
+
+	result := output.NewResult(map[string]interface{}{
+		"success": true,
+		"profile": profile,
+		"origin":  creds.Origin.String(),
+		"email":   creds.Email,
+		"keyPath": creds.KeyPath,
+	})
+	return outputResult(result, globals.Output, globals.Pretty)
 }
 
-// AuthLogoutCmd signs out and clears credentials.
-type AuthLogoutCmd struct{}
+// AuthLogoutCmd signs out and clears stored credentials for a profile.
+// Note: use --name (not --profile) so it does not collide with the global --profile flag.
+type AuthLogoutCmd struct {
+	Name string `name:"name" help:"Profile to sign out of (default: active profile)"`
+	All  bool   `help:"Sign out of all profiles and clear all stored credentials"`
+}
 
 // Run executes the auth logout command.
 func (cmd *AuthLogoutCmd) Run(globals *Globals) error {
 	authMgr := newAuthManager()
-	authMgr.Clear()
 
-	fmt.Println("Signed out successfully")
+	if cmd.All {
+		if err := authMgr.ClearAllProfiles(); err != nil {
+			return errors.NewAPIError(errors.CodeGeneralError,
+				fmt.Sprintf("failed to clear all profiles: %v", err))
+		}
+		result := output.NewResult(map[string]interface{}{
+			"success": true,
+			"all":     true,
+			"message": "Signed out of all profiles",
+		})
+		return outputResult(result, globals.Output, globals.Pretty)
+	}
+
+	profile := strings.TrimSpace(cmd.Name)
+	if profile == "" {
+		profile = authMgr.GetActiveProfile()
+	}
+	if profile == "" {
+		profile = "default"
+	}
+
+	if err := authMgr.ClearProfile(profile); err != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("failed to clear profile %q: %v", profile, err))
+	}
+
+	result := output.NewResult(map[string]interface{}{
+		"success": true,
+		"profile": profile,
+		"message": "Signed out successfully",
+	})
+	return outputResult(result, globals.Output, globals.Pretty)
+}
+
+// AuthDeleteCmd removes a stored authentication profile.
+type AuthDeleteCmd struct {
+	Profile string `arg:"" help:"Profile name to delete" required:""`
+	Force   bool   `help:"Allow deleting the currently active profile (switches to default)"`
+}
+
+// Run executes the auth delete command.
+func (cmd *AuthDeleteCmd) Run(globals *Globals) error {
+	profile := strings.TrimSpace(cmd.Profile)
+	if profile == "" {
+		return errors.NewAPIError(errors.CodeValidationError, "profile name is required")
+	}
+
+	authMgr := newAuthManager()
+	active := resolveCLIActiveProfile(authMgr)
+
+	if profile == active && !cmd.Force {
+		return errors.NewAPIError(errors.CodeValidationError,
+			fmt.Sprintf("cannot delete active profile %q without --force", profile)).
+			WithHint("Switch to another profile first, or pass --force to delete and switch to default")
+	}
+
+	existed, err := authMgr.DeleteProfile(profile)
+	if err != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("failed to delete profile %q: %v", profile, err))
+	}
+	if !existed {
+		return errors.NewAPIError(errors.CodeNotFound,
+			fmt.Sprintf("profile %q not found", profile)).
+			WithHint("Run `gpd auth list` to see stored profiles")
+	}
+
+	switchedTo := ""
+	if profile == active {
+		if err := config.SetActiveProfile("default"); err != nil {
+			return errors.NewAPIError(errors.CodeGeneralError,
+				fmt.Sprintf("deleted profile but failed to switch to default: %v", err)).
+				WithHint("Run `gpd auth switch default` manually")
+		}
+		globals.Profile = "default"
+		applyAuthGlobals(globals)
+		switchedTo = "default"
+	}
+
+	data := map[string]interface{}{
+		"success": true,
+		"profile": profile,
+		"deleted": true,
+		"message": fmt.Sprintf("Deleted profile %q", profile),
+	}
+	if switchedTo != "" {
+		data["activeProfile"] = switchedTo
+		data["message"] = fmt.Sprintf("Deleted active profile %q; switched to %q", profile, switchedTo)
+	}
+
+	result := output.NewResult(data)
+	return outputResult(result, globals.Output, globals.Pretty)
+}
+
+// resolveCLIActiveProfile returns the effective active profile from manager + config.
+func resolveCLIActiveProfile(authMgr *auth.Manager) string {
+	active := "default"
+	if authMgr != nil {
+		active = authMgr.GetActiveProfile()
+	}
+	if cfg, loadErr := config.Load(); loadErr == nil && cfg != nil && cfg.ActiveProfile != "" {
+		active = cfg.ActiveProfile
+	}
+	return active
+}
+
+// AuthListCmd lists stored authentication profiles.
+type AuthListCmd struct{}
+
+// Run executes the auth list command.
+func (cmd *AuthListCmd) Run(globals *Globals) error {
+	authMgr := newAuthManager()
+	profiles, err := authMgr.ListProfiles()
+	if err != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("failed to list profiles: %v", err))
+	}
+
+	active := authMgr.GetActiveProfile()
+	if cfg, loadErr := config.Load(); loadErr == nil && cfg != nil && cfg.ActiveProfile != "" {
+		active = cfg.ActiveProfile
+	}
+
+	type profileRow struct {
+		Profile   string   `json:"profile"`
+		Active    bool     `json:"active"`
+		Origin    string   `json:"origin,omitempty"`
+		Email     string   `json:"email,omitempty"`
+		Scopes    []string `json:"scopes,omitempty"`
+		UpdatedAt string   `json:"updatedAt,omitempty"`
+		Expiry    string   `json:"tokenExpiry,omitempty"`
+	}
+
+	rows := make([]profileRow, 0, len(profiles))
+	seen := map[string]bool{}
+	for _, p := range profiles {
+		rows = append(rows, profileRow{
+			Profile:   p.Profile,
+			Active:    p.Profile == active,
+			Origin:    p.Origin,
+			Email:     p.Email,
+			Scopes:    p.Scopes,
+			UpdatedAt: p.UpdatedAt,
+			Expiry:    p.TokenExpiry,
+		})
+		seen[p.Profile] = true
+	}
+	// Always surface the active profile even when no token metadata exists yet.
+	if !seen[active] {
+		rows = append([]profileRow{{
+			Profile: active,
+			Active:  true,
+		}}, rows...)
+	}
+
+	result := output.NewResult(map[string]interface{}{
+		"activeProfile": active,
+		"profiles":      rows,
+		"count":         len(rows),
+	})
+	return outputResult(result, globals.Output, globals.Pretty)
+}
+
+// AuthSwitchCmd switches the active authentication profile.
+type AuthSwitchCmd struct {
+	Profile string `arg:"" help:"Profile name to activate" required:""`
+}
+
+// Run executes the auth switch command.
+func (cmd *AuthSwitchCmd) Run(globals *Globals) error {
+	profile := strings.TrimSpace(cmd.Profile)
+	if profile == "" {
+		return errors.NewAPIError(errors.CodeValidationError, "profile name is required")
+	}
+
+	authMgr := newAuthManager()
+	profiles, err := authMgr.ListProfiles()
+	if err != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("failed to list profiles: %v", err))
+	}
+
+	found := profile == "default"
+	var meta *auth.TokenMetadata
+	for i := range profiles {
+		if profiles[i].Profile == profile {
+			found = true
+			meta = &profiles[i]
+			break
+		}
+	}
+	if !found {
+		return errors.NewAPIError(errors.CodeNotFound,
+			fmt.Sprintf("profile %q not found", profile)).
+			WithHint("Run `gpd auth list` to see stored profiles, or `gpd auth login <profile> --key ...` to create one")
+	}
+
+	if err := config.SetActiveProfile(profile); err != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("failed to set active profile: %v", err))
+	}
+	globals.Profile = profile
+	applyAuthGlobals(globals)
+
+	data := map[string]interface{}{
+		"success": true,
+		"profile": profile,
+		"active":  true,
+	}
+	if meta != nil {
+		data["origin"] = meta.Origin
+		data["email"] = meta.Email
+		data["updatedAt"] = meta.UpdatedAt
+	}
+
+	result := output.NewResult(data)
+	return outputResult(result, globals.Output, globals.Pretty)
+}
+
+// AuthCheckCmd validates that credentials can access a package.
+// Use the global --package flag.
+type AuthCheckCmd struct{}
+
+// Run executes the auth check command.
+func (cmd *AuthCheckCmd) Run(globals *Globals) error {
+	ctx := authContext(globals)
+	pkg := strings.TrimSpace(globals.Package)
+	if err := requirePackage(pkg); err != nil {
+		return errors.NewAPIError(errors.CodeValidationError, err.Error()).
+			WithHint("Pass --package com.example.app")
+	}
+
+	authMgr := newAuthManager()
+	creds, err := authMgr.Authenticate(ctx, globals.KeyPath)
+	if err != nil {
+		return err
+	}
+
+	client, err := api.NewClient(ctx, creds.TokenSource,
+		api.WithTimeout(globals.Timeout),
+		api.WithVerboseLogging(globals.Verbose))
+	if err != nil {
+		return err
+	}
+
+	svc, err := client.AndroidPublisher()
+	if err != nil {
+		return err
+	}
+
+	permissions := []*auth.PermissionCheck{}
+	valid := true
+
+	// Probe: create a disposable edit, then delete it.
+	editCheck := &auth.PermissionCheck{
+		Surface:  "androidpublisher.edits",
+		TestCall: "edits.insert+edits.delete",
+	}
+	edit, editErr := svc.Edits.Insert(pkg, &androidpublisher.AppEdit{}).Context(ctx).Do()
+	if editErr != nil {
+		valid = false
+		editCheck.HasAccess = false
+		editCheck.Error = editErr.Error()
+	} else {
+		editCheck.HasAccess = true
+		if delErr := svc.Edits.Delete(pkg, edit.Id).Context(ctx).Do(); delErr != nil {
+			// Access worked; cleanup failure is non-fatal but reported.
+			editCheck.Error = fmt.Sprintf("cleanup failed: %v", delErr)
+		}
+	}
+	permissions = append(permissions, editCheck)
+
+	check := &auth.CheckResult{
+		Valid:       valid,
+		Origin:      creds.Origin.String(),
+		Email:       creds.Email,
+		Permissions: permissions,
+	}
+
+	result := output.NewResult(map[string]interface{}{
+		"package":     pkg,
+		"profile":     authMgr.GetActiveProfile(),
+		"valid":       check.Valid,
+		"origin":      check.Origin,
+		"email":       check.Email,
+		"permissions": check.Permissions,
+	})
+
+	if !valid {
+		// Still emit structured output, then return a typed error for exit code.
+		_ = outputResult(result, globals.Output, globals.Pretty)
+		return errors.NewAPIError(errors.CodePermissionDenied,
+			fmt.Sprintf("credentials cannot access package %s", pkg)).
+			WithHint("Grant the service account Android Publisher access for this app in Play Console")
+	}
+
+	return outputResult(result, globals.Output, globals.Pretty)
+}
+
+// AuthDoctorCmd diagnoses authentication setup.
+type AuthDoctorCmd struct {
+	RefreshCheck bool `help:"Attempt token refresh / credential load" name:"refresh-check"`
+	Network      bool `help:"Run a lightweight network permission probe (requires --package)"`
+}
+
+// Run executes the auth doctor command.
+func (cmd *AuthDoctorCmd) Run(globals *Globals) error {
+	return runAuthDoctor(globals, cmd.RefreshCheck, cmd.Network)
+}
+
+// AuthDiagnoseCmd is an alias of doctor with the same flags.
+type AuthDiagnoseCmd struct {
+	RefreshCheck bool `help:"Attempt token refresh / credential load" name:"refresh-check"`
+	Network      bool `help:"Run a lightweight network permission probe (requires --package)"`
+}
+
+// Run executes the auth diagnose command.
+func (cmd *AuthDiagnoseCmd) Run(globals *Globals) error {
+	return runAuthDoctor(globals, cmd.RefreshCheck, cmd.Network)
+}
+
+type doctorCheck struct {
+	Status         string `json:"status"` // ok, warn, fail, info
+	Message        string `json:"message"`
+	Recommendation string `json:"recommendation,omitempty"`
+}
+
+type doctorSection struct {
+	Title  string        `json:"title"`
+	Checks []doctorCheck `json:"checks"`
+}
+
+type doctorSummary struct {
+	OK       int `json:"ok"`
+	Info     int `json:"info"`
+	Warnings int `json:"warnings"`
+	Errors   int `json:"errors"`
+}
+
+func runAuthDoctor(globals *Globals, refreshCheck, network bool) error {
+	ctx := authContext(globals)
+	sections := []doctorSection{}
+	recommendations := []string{}
+
+	// Section: Environment
+	envChecks := []doctorCheck{}
+	if key := config.GetEnvServiceAccountKey(); key != "" {
+		envChecks = append(envChecks, doctorCheck{Status: "ok", Message: "GPD_SERVICE_ACCOUNT_KEY is set"})
+	} else {
+		envChecks = append(envChecks, doctorCheck{Status: "info", Message: "GPD_SERVICE_ACCOUNT_KEY is not set"})
+	}
+	if gac := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); gac != "" {
+		if _, err := os.Stat(gac); err == nil {
+			envChecks = append(envChecks, doctorCheck{Status: "ok", Message: "GOOGLE_APPLICATION_CREDENTIALS points to an existing file"})
+		} else {
+			envChecks = append(envChecks, doctorCheck{
+				Status:         "fail",
+				Message:        "GOOGLE_APPLICATION_CREDENTIALS is set but file is missing",
+				Recommendation: "Fix the path or unset GOOGLE_APPLICATION_CREDENTIALS",
+			})
+			recommendations = append(recommendations, "Fix or unset GOOGLE_APPLICATION_CREDENTIALS")
+		}
+	} else {
+		envChecks = append(envChecks, doctorCheck{Status: "info", Message: "GOOGLE_APPLICATION_CREDENTIALS is not set"})
+	}
+	if p := config.GetEnvAuthProfile(); p != "" {
+		envChecks = append(envChecks, doctorCheck{Status: "info", Message: fmt.Sprintf("GPD_AUTH_PROFILE=%s", p)})
+	}
+	sections = append(sections, doctorSection{Title: "Environment", Checks: envChecks})
+
+	// Section: Storage
+	store := storage.New()
+	storeChecks := []doctorCheck{
+		{
+			Status:  boolStatus(store.Available(), "ok", "warn"),
+			Message: fmt.Sprintf("Secure storage available=%v platform=%s", store.Available(), storage.Platform()),
+		},
+	}
+	if !store.Available() {
+		storeChecks[0].Recommendation = "Tokens will stay in memory only; set --store-tokens=never in CI or use service account --key"
+		recommendations = append(recommendations, "Secure storage unavailable; prefer --key service-account JSON in CI")
+	}
+	paths := config.GetPaths()
+	if _, err := os.Stat(paths.ConfigDir); err == nil {
+		storeChecks = append(storeChecks, doctorCheck{Status: "ok", Message: "Config directory exists: " + paths.ConfigDir})
+	} else {
+		storeChecks = append(storeChecks, doctorCheck{
+			Status:         "warn",
+			Message:        "Config directory missing: " + paths.ConfigDir,
+			Recommendation: "Run `gpd config init` or `gpd auth login --key ...`",
+		})
+	}
+	sections = append(sections, doctorSection{Title: "Storage", Checks: storeChecks})
+
+	// Section: Profiles
+	authMgr := newAuthManager()
+	active := authMgr.GetActiveProfile()
+	if cfg, err := config.Load(); err == nil && cfg != nil && cfg.ActiveProfile != "" {
+		active = cfg.ActiveProfile
+	}
+	profiles, listErr := authMgr.ListProfiles()
+	profileChecks := []doctorCheck{
+		{Status: "info", Message: fmt.Sprintf("Active profile: %s", active)},
+	}
+	if listErr != nil {
+		profileChecks = append(profileChecks, doctorCheck{
+			Status:  "fail",
+			Message: fmt.Sprintf("Failed to list profiles: %v", listErr),
+		})
+	} else {
+		profileChecks = append(profileChecks, doctorCheck{
+			Status:  "ok",
+			Message: fmt.Sprintf("Stored profiles: %d", len(profiles)),
+		})
+		for _, p := range profiles {
+			profileChecks = append(profileChecks, doctorCheck{
+				Status:  "info",
+				Message: fmt.Sprintf("profile=%s origin=%s email=%s", p.Profile, p.Origin, p.Email),
+			})
+		}
+	}
+	sections = append(sections, doctorSection{Title: "Profiles", Checks: profileChecks})
+
+	// Section: Credentials (optional refresh)
+	credChecks := []doctorCheck{}
+	if refreshCheck || globals.KeyPath != "" {
+		creds, err := authMgr.Authenticate(ctx, globals.KeyPath)
+		if err != nil {
+			credChecks = append(credChecks, doctorCheck{
+				Status:         "fail",
+				Message:        fmt.Sprintf("Credential load failed: %v", err),
+				Recommendation: "Run `gpd auth login --key /path/to/service-account.json`",
+			})
+			recommendations = append(recommendations, "Re-authenticate with a valid service account key or ADC")
+		} else {
+			credChecks = append(credChecks, doctorCheck{
+				Status:  "ok",
+				Message: fmt.Sprintf("Credentials loaded origin=%s email=%s", creds.Origin.String(), creds.Email),
+			})
+			status, stErr := authMgr.GetStatus(ctx)
+			if stErr != nil {
+				credChecks = append(credChecks, doctorCheck{Status: "warn", Message: stErr.Error()})
+			} else if status != nil {
+				if status.TokenValid {
+					credChecks = append(credChecks, doctorCheck{Status: "ok", Message: "Token is valid"})
+				} else {
+					credChecks = append(credChecks, doctorCheck{
+						Status:         "fail",
+						Message:        "Token is not valid",
+						Recommendation: "Re-run `gpd auth login` or check clock skew",
+					})
+					recommendations = append(recommendations, "Re-authenticate; token is invalid or expired")
+				}
+			}
+		}
+	} else {
+		credChecks = append(credChecks, doctorCheck{
+			Status:         "info",
+			Message:        "Skipped credential load (pass --refresh-check or --key-path)",
+			Recommendation: "Use --refresh-check to validate token acquisition",
+		})
+	}
+	sections = append(sections, doctorSection{Title: "Credentials", Checks: credChecks})
+
+	// Section: Network probe
+	if network {
+		netChecks := []doctorCheck{}
+		pkg := strings.TrimSpace(globals.Package)
+		if pkg == "" {
+			netChecks = append(netChecks, doctorCheck{
+				Status:         "fail",
+				Message:        "Network probe requested but --package is empty",
+				Recommendation: "Pass --package com.example.app with --network",
+			})
+			recommendations = append(recommendations, "Provide --package for network permission probe")
+		} else {
+			if err := probePackageAccess(ctx, globals, pkg); err != nil {
+				netChecks = append(netChecks, doctorCheck{
+					Status:         "fail",
+					Message:        fmt.Sprintf("Package access failed for %s: %v", pkg, err),
+					Recommendation: "Grant Play Console access to the service account for this package",
+				})
+				recommendations = append(recommendations, "Fix Play Console user access for the service account")
+			} else {
+				netChecks = append(netChecks, doctorCheck{
+					Status:  "ok",
+					Message: fmt.Sprintf("Package access OK for %s", pkg),
+				})
+			}
+		}
+		sections = append(sections, doctorSection{Title: "Network", Checks: netChecks})
+	}
+
+	// Section: Runtime
+	sections = append(sections, doctorSection{
+		Title: "Runtime",
+		Checks: []doctorCheck{
+			{Status: "info", Message: fmt.Sprintf("goos=%s goarch=%s", runtime.GOOS, runtime.GOARCH)},
+			{Status: "info", Message: fmt.Sprintf("timeout=%s storeTokens=%s", globals.Timeout, globals.StoreTokens)},
+		},
+	})
+
+	summary := doctorSummary{}
+	for _, sec := range sections {
+		for _, c := range sec.Checks {
+			switch c.Status {
+			case "ok":
+				summary.OK++
+			case "info":
+				summary.Info++
+			case "warn":
+				summary.Warnings++
+			case "fail":
+				summary.Errors++
+			}
+		}
+	}
+
+	report := map[string]interface{}{
+		"sections":        sections,
+		"summary":         summary,
+		"recommendations": recommendations,
+		"activeProfile":   active,
+		"generatedAt":     time.Now().UTC().Format(time.RFC3339),
+	}
+
+	result := output.NewResult(report)
+	if err := outputResult(result, globals.Output, globals.Pretty); err != nil {
+		return err
+	}
+	if summary.Errors > 0 {
+		return errors.NewAPIError(errors.CodeAuthFailure, "auth doctor found failures").
+			WithHint("Review recommendations in the doctor report")
+	}
 	return nil
+}
+
+func probePackageAccess(ctx context.Context, globals *Globals, pkg string) error {
+	authMgr := newAuthManager()
+	creds, err := authMgr.Authenticate(ctx, globals.KeyPath)
+	if err != nil {
+		return err
+	}
+	client, err := api.NewClient(ctx, creds.TokenSource,
+		api.WithTimeout(globals.Timeout),
+		api.WithVerboseLogging(globals.Verbose))
+	if err != nil {
+		return err
+	}
+	svc, err := client.AndroidPublisher()
+	if err != nil {
+		return err
+	}
+	edit, err := svc.Edits.Insert(pkg, &androidpublisher.AppEdit{}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	_ = svc.Edits.Delete(pkg, edit.Id).Context(ctx).Do()
+	return nil
+}
+
+func authContext(globals *Globals) context.Context {
+	if globals != nil && globals.Context != nil {
+		return globals.Context
+	}
+	return context.Background()
+}
+
+func boolStatus(ok bool, whenTrue, whenFalse string) string {
+	if ok {
+		return whenTrue
+	}
+	return whenFalse
 }

--- a/internal/cli/kong_auth_test.go
+++ b/internal/cli/kong_auth_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/auth"
 	gpdErrors "github.com/dl-alexandre/Google-Play-Developer-CLI/internal/errors"
@@ -234,20 +235,108 @@ func TestAuthLogoutCmd_AlreadyLoggedOut(t *testing.T) {
 func TestAuthCmd_SubcommandsExist(t *testing.T) {
 	cmd := AuthCmd{}
 
-	// Verify Status field exists
-	if reflect.TypeOf(cmd.Status).String() != "cli.AuthStatusCmd" {
-		t.Errorf("AuthCmd.Status type = %v, want cli.AuthStatusCmd", reflect.TypeOf(cmd.Status))
+	want := map[string]string{
+		"Status":   "cli.AuthStatusCmd",
+		"Login":    "cli.AuthLoginCmd",
+		"Init":     "cli.AuthInitCmd",
+		"Logout":   "cli.AuthLogoutCmd",
+		"Delete":   "cli.AuthDeleteCmd",
+		"List":     "cli.AuthListCmd",
+		"Switch":   "cli.AuthSwitchCmd",
+		"Check":    "cli.AuthCheckCmd",
+		"Doctor":   "cli.AuthDoctorCmd",
+		"Diagnose": "cli.AuthDiagnoseCmd",
 	}
 
-	// Verify Login field exists
-	if reflect.TypeOf(cmd.Login).String() != "cli.AuthLoginCmd" {
-		t.Errorf("AuthCmd.Login type = %v, want cli.AuthLoginCmd", reflect.TypeOf(cmd.Login))
+	val := reflect.ValueOf(cmd)
+	typ := reflect.TypeOf(cmd)
+	for name, wantType := range want {
+		field, ok := typ.FieldByName(name)
+		if !ok {
+			t.Errorf("AuthCmd missing field %s", name)
+			continue
+		}
+		got := field.Type.String()
+		if got != wantType {
+			t.Errorf("AuthCmd.%s type = %v, want %s", name, got, wantType)
+		}
+		_ = val
 	}
+}
 
-	// Verify Logout field exists
-	if reflect.TypeOf(cmd.Logout).String() != "cli.AuthLogoutCmd" {
-		t.Errorf("AuthCmd.Logout type = %v, want cli.AuthLogoutCmd", reflect.TypeOf(cmd.Logout))
+// TestAuthListCmd_Empty runs list with no stored profiles.
+func TestAuthListCmd_Empty(t *testing.T) {
+	cmd := &AuthListCmd{}
+	globals := &Globals{Output: "json", Profile: "default"}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("AuthListCmd.Run() unexpected error: %v", err)
 	}
+}
+
+// TestAuthSwitchCmd_Default allows switching to default without stored metadata.
+func TestAuthSwitchCmd_Default(t *testing.T) {
+	// Isolate config dir
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	cmd := &AuthSwitchCmd{Profile: "default"}
+	globals := &Globals{Output: "json"}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("AuthSwitchCmd.Run() unexpected error: %v", err)
+	}
+}
+
+// TestAuthSwitchCmd_Missing fails for unknown profiles.
+func TestAuthSwitchCmd_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	cmd := &AuthSwitchCmd{Profile: "does-not-exist"}
+	globals := &Globals{Output: "json"}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err == nil {
+		t.Fatal("AuthSwitchCmd.Run() expected error for missing profile")
+	}
+}
+
+// TestAuthDoctorCmd_NoRefresh runs doctor without credential load.
+func TestAuthDoctorCmd_NoRefresh(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	cmd := &AuthDoctorCmd{}
+	globals := &Globals{Output: "json", StoreTokens: "never", Timeout: time.Second}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err != nil {
+		// Doctor may return auth failure only when summary.Errors > 0.
+		// With no refresh check, empty env should still succeed.
+		var apiErr *gpdErrors.APIError
+		if errors.As(err, &apiErr) {
+			t.Fatalf("AuthDoctorCmd.Run() unexpected API error: %v", err)
+		}
+		t.Fatalf("AuthDoctorCmd.Run() unexpected error: %v", err)
+	}
+}
+
+// TestAuthCheckCmd_RequiresPackage validates package is required.
+func TestAuthCheckCmd_RequiresPackage(t *testing.T) {
+	cmd := &AuthCheckCmd{}
+	globals := &Globals{Output: "json"}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err == nil {
+		t.Fatal("AuthCheckCmd.Run() expected error without package")
+	}
+}
+
+// TestResolveAuthProfileViaGlobals ensures applyAuthGlobals is safe.
+func TestApplyAuthGlobals_NilSafe(t *testing.T) {
+	applyAuthGlobals(nil)
+	_ = newAuthManager()
 }
 
 // TestAuthLoginCmd_StructFields tests AuthLoginCmd struct fields and tags
@@ -584,5 +673,216 @@ func TestAuthLogoutCmd_MultipleCalls(t *testing.T) {
 		if err != nil {
 			t.Fatalf("AuthLogoutCmd.Run() call %d unexpected error: %v", i+1, err)
 		}
+	}
+}
+
+func TestAuthLogoutCmd_WithProfileFlag(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	// Seed metadata for a named profile via auth package helpers (login may not write meta without secure storage).
+	metaDir := filepath.Join(tmp, ".config", "gpd", "tokens")
+	if err := os.MkdirAll(metaDir, 0o700); err != nil {
+		// Paths may differ by platform; fall through using login + store-tokens never still exercises Run().
+		t.Logf("mkdir tokens (may vary by OS path layout): %v", err)
+	}
+
+	cmd := &AuthLogoutCmd{Name: "staging"}
+	globals := &Globals{Output: "json", Profile: "default"}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("AuthLogoutCmd.Run() with --profile unexpected error: %v", err)
+	}
+}
+
+func TestAuthLogoutCmd_All(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	cmd := &AuthLogoutCmd{All: true}
+	globals := &Globals{Output: "json"}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("AuthLogoutCmd.Run() --all unexpected error: %v", err)
+	}
+}
+
+func TestAuthDeleteCmd_MissingProfile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	cmd := &AuthDeleteCmd{Profile: "does-not-exist"}
+	globals := &Globals{Output: "json", Profile: "default"}
+	applyAuthGlobals(globals)
+	err := cmd.Run(globals)
+	if err == nil {
+		t.Fatal("AuthDeleteCmd.Run() expected not-found error")
+	}
+	var apiErr *gpdErrors.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.ExitCode() != gpdErrors.ExitNotFound && apiErr.Code != gpdErrors.CodeNotFound {
+			// Accept either typed not-found semantics.
+			t.Logf("delete missing profile error: %v", err)
+		}
+	}
+}
+
+func TestAuthDeleteCmd_RefuseActiveWithoutForce(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	// Create token metadata so DeleteProfile would find the profile if force allowed.
+	tokensDir := filepath.Join(tmp, ".config", "gpd", "tokens")
+	if err := os.MkdirAll(tokensDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	meta := map[string]string{
+		"profile":      "active-one",
+		"clientIdHash": "hash",
+		"origin":       "keyfile",
+		"updatedAt":    time.Now().UTC().Format(time.RFC3339),
+	}
+	data, _ := json.Marshal(meta)
+	metaPath := filepath.Join(tokensDir, "active-one--hash.meta.json")
+	if err := os.WriteFile(metaPath, data, 0o600); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	// Persist active profile via switch-like config write.
+	if err := (&AuthSwitchCmd{Profile: "active-one"}).Run(&Globals{Output: "json", Profile: "active-one"}); err != nil {
+		// Switch requires profile in list — we wrote meta so it should work if config path matches.
+		// If path layout differs, set globals.Profile and applyAuthGlobals instead.
+		t.Logf("switch note: %v", err)
+	}
+
+	cmd := &AuthDeleteCmd{Profile: "active-one", Force: false}
+	globals := &Globals{Output: "json", Profile: "active-one"}
+	applyAuthGlobals(globals)
+	err := cmd.Run(globals)
+	if err == nil {
+		t.Fatal("AuthDeleteCmd.Run() expected error deleting active profile without --force")
+	}
+}
+
+func TestAuthDeleteCmd_ForceActiveSwitchesToDefault(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	// Also set HOME-style path used by config.GetPaths on macOS.
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, ".cache"))
+
+	tokensDir := filepath.Join(tmp, ".config", "gpd", "tokens")
+	if err := os.MkdirAll(tokensDir, 0o700); err != nil {
+		// Discover real tokens path via list after writing through auth if needed.
+		t.Logf("mkdir primary tokens dir: %v", err)
+	}
+	meta := map[string]interface{}{
+		"profile":      "doomed",
+		"clientIdHash": "hash",
+		"origin":       "keyfile",
+		"updatedAt":    time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Write under both common config layouts used in tests.
+	for _, dir := range []string{
+		filepath.Join(tmp, ".config", "gpd", "tokens"),
+		filepath.Join(tmp, "Library", "Application Support", "gpd", "tokens"),
+	} {
+		_ = os.MkdirAll(dir, 0o700)
+		_ = os.WriteFile(filepath.Join(dir, "doomed--hash.meta.json"), data, 0o600)
+	}
+
+	// Make doomed active via config + globals.
+	switchCmd := &AuthSwitchCmd{Profile: "doomed"}
+	switchGlobals := &Globals{Output: "json", Profile: "doomed"}
+	applyAuthGlobals(switchGlobals)
+	if err := switchCmd.Run(switchGlobals); err != nil {
+		// Fallback: still test delete --force path with active matching globals.
+		t.Logf("AuthSwitchCmd note: %v", err)
+	}
+
+	delCmd := &AuthDeleteCmd{Profile: "doomed", Force: true}
+	delGlobals := &Globals{Output: "json", Profile: "doomed"}
+	applyAuthGlobals(delGlobals)
+	if err := delCmd.Run(delGlobals); err != nil {
+		t.Fatalf("AuthDeleteCmd.Run() --force unexpected error: %v", err)
+	}
+
+	// Deleting again should report not found.
+	if err := delCmd.Run(delGlobals); err == nil {
+		t.Fatal("second delete expected not found")
+	}
+}
+
+func TestAuthDeleteCmd_NonActive(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, ".cache"))
+
+	meta := map[string]interface{}{
+		"profile":      "old-team",
+		"clientIdHash": "h",
+		"origin":       "oauth",
+		"updatedAt":    time.Now().UTC().Format(time.RFC3339),
+	}
+	data, _ := json.MarshalIndent(meta, "", "  ")
+	for _, dir := range []string{
+		filepath.Join(tmp, ".config", "gpd", "tokens"),
+		filepath.Join(tmp, "Library", "Application Support", "gpd", "tokens"),
+	} {
+		_ = os.MkdirAll(dir, 0o700)
+		_ = os.WriteFile(filepath.Join(dir, "old-team--h.meta.json"), data, 0o600)
+	}
+
+	cmd := &AuthDeleteCmd{Profile: "old-team"}
+	globals := &Globals{Output: "json", Profile: "default"}
+	applyAuthGlobals(globals)
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("AuthDeleteCmd.Run() non-active unexpected error: %v", err)
+	}
+}
+
+func TestAuthDeleteCmd_EmptyProfile(t *testing.T) {
+	cmd := &AuthDeleteCmd{Profile: "  "}
+	globals := &Globals{Output: "json"}
+	if err := cmd.Run(globals); err == nil {
+		t.Fatal("expected validation error for empty profile")
+	}
+}
+
+func TestAuthDeleteCmd_StructFields(t *testing.T) {
+	cmd := AuthDeleteCmd{Profile: "p", Force: true}
+	if cmd.Profile != "p" || !cmd.Force {
+		t.Fatalf("unexpected fields: %+v", cmd)
+	}
+	typ := reflect.TypeOf(cmd)
+	prof, ok := typ.FieldByName("Profile")
+	if !ok {
+		t.Fatal("AuthDeleteCmd missing Profile field")
+	}
+	if _, hasArg := prof.Tag.Lookup("arg"); !hasArg {
+		t.Fatal("AuthDeleteCmd.Profile should be a Kong arg")
+	}
+}
+
+func TestAuthLogoutCmd_StructFields(t *testing.T) {
+	cmd := AuthLogoutCmd{Name: "p", All: true}
+	if cmd.Name != "p" || !cmd.All {
+		t.Fatalf("unexpected fields: %+v", cmd)
+	}
+	typ := reflect.TypeOf(cmd)
+	if _, ok := typ.FieldByName("All"); !ok {
+		t.Fatal("AuthLogoutCmd missing All field")
+	}
+	if _, ok := typ.FieldByName("Name"); !ok {
+		t.Fatal("AuthLogoutCmd missing Name field")
 	}
 }

--- a/internal/cli/kong_cli.go
+++ b/internal/cli/kong_cli.go
@@ -13,6 +13,8 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/cache"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/cli/outfmt"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/config"
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/errors"
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/extensions"
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/logging"
@@ -21,7 +23,7 @@ import (
 // Globals contains all global flags shared across all commands.
 type Globals struct {
 	Package     string        `help:"App package name" short:"p"`
-	Output      string        `help:"Output format: json, table, markdown, csv, excel" default:"json" enum:"json,table,markdown,csv,excel"`
+	Output      string        `help:"Output format: json, table, markdown, csv, excel (default: table on TTY, json in pipes/CI; override with GPD_DEFAULT_OUTPUT)" default:"json" enum:"json,table,markdown,csv,excel"`
 	Pretty      bool          `help:"Pretty print JSON output"`
 	Timeout     time.Duration `help:"Network timeout" default:"30s"`
 	StoreTokens string        `help:"Token storage: auto, never, secure" default:"auto" enum:"auto,never,secure"`
@@ -76,6 +78,9 @@ type KongCLI struct {
 	Automation  AutomationCmd  `cmd:"" help:"CI/CD release automation"`
 	Workflow    WorkflowCmd    `cmd:"" help:"Declarative workflow execution"`
 
+	// High-level operator commands (ASC-style job ergonomics)
+	Validate ValidateCmd `cmd:"" help:"Submission readiness / pre-publish validation report"`
+
 	// Extension commands
 	Extension ExtensionCmd `cmd:"" help:"Manage CLI extensions"`
 
@@ -128,6 +133,13 @@ func RunKongCLI() int {
 		return errors.ExitValidationError
 	}
 
+	// Resolve auth profile once for all commands:
+	// --profile > GPD_AUTH_PROFILE > config activeProfile > "default"
+	cli.Profile = config.ResolveAuthProfile(cli.Profile)
+	// TTY-aware output: explicit --output > GPD_DEFAULT_OUTPUT > table(TTY)/json(pipe)
+	cli.Output = outfmt.ResolveOutputFromEnvAndTTY(cli.Output, os.Args[1:])
+	applyAuthGlobals(&cli.Globals)
+
 	// Set up verbose logging if requested
 	if cli.Verbose {
 		logger := logging.NewLogger(os.Stderr, true)
@@ -143,6 +155,7 @@ func RunKongCLI() int {
 
 	logging.Debug("Command execution started",
 		logging.String("timeout", cli.Timeout.String()),
+		logging.String("profile", cli.Profile),
 	)
 
 	// Execute the selected command

--- a/internal/cli/kong_commands_test.go
+++ b/internal/cli/kong_commands_test.go
@@ -19,7 +19,7 @@ func TestPublishCmd_HasExpectedSubcommands(t *testing.T) {
 	typeOfCmd := v.Type()
 
 	expectedSubcommands := []string{
-		"Upload", "Release", "Rollout", "Promote", "Halt", "Rollback",
+		"Play", "Upload", "Release", "Rollout", "Promote", "Halt", "Rollback",
 		"Status", "Tracks", "Capabilities", "Listing", "Details", "Images",
 		"Assets", "Deobfuscation", "Testers", "Builds", "BetaGroups", "InternalShare",
 	}

--- a/internal/cli/kong_helpers.go
+++ b/internal/cli/kong_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/auth"
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/output"
@@ -17,10 +18,43 @@ const (
 	formatExcel    = "excel"
 )
 
-// newAuthManager creates a new auth manager instance.
+// Package-level auth defaults applied after globals are resolved in RunKongCLI.
+// This keeps existing newAuthManager() call sites profile-aware without a
+// wide refactor of every command package.
+var (
+	authDefaultsMu     sync.RWMutex
+	authDefaultProfile string
+	authDefaultStore   string
+)
+
+// applyAuthGlobals records profile and store-tokens defaults for newAuthManager.
+func applyAuthGlobals(globals *Globals) {
+	if globals == nil {
+		return
+	}
+	authDefaultsMu.Lock()
+	defer authDefaultsMu.Unlock()
+	authDefaultProfile = strings.TrimSpace(globals.Profile)
+	authDefaultStore = strings.TrimSpace(globals.StoreTokens)
+}
+
+// newAuthManager creates a new auth manager instance with resolved defaults.
 func newAuthManager() *auth.Manager {
 	secureStorage := storage.New()
-	return auth.NewManager(secureStorage)
+	mgr := auth.NewManager(secureStorage)
+
+	authDefaultsMu.RLock()
+	profile := authDefaultProfile
+	store := authDefaultStore
+	authDefaultsMu.RUnlock()
+
+	if store != "" {
+		mgr.SetStoreTokens(store)
+	}
+	if profile != "" {
+		mgr.SetActiveProfile(profile)
+	}
+	return mgr
 }
 
 // outputResult formats and outputs a result based on the format.

--- a/internal/cli/kong_publish.go
+++ b/internal/cli/kong_publish.go
@@ -16,12 +16,14 @@ import (
 	"google.golang.org/api/googleapi"
 
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/api"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/cli/playship"
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/errors"
 	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/output"
 )
 
 // PublishCmd contains publishing commands.
 type PublishCmd struct {
+	Play          PublishPlayCmd          `cmd:"" help:"High-level upload→track→status publish job (ASC publish analogue)"`
 	Upload        PublishUploadCmd        `cmd:"" help:"Upload APK or AAB"`
 	Release       PublishReleaseCmd       `cmd:"" help:"Create or update a release"`
 	Rollout       PublishRolloutCmd       `cmd:"" help:"Update rollout percentage"`
@@ -40,6 +42,145 @@ type PublishCmd struct {
 	Builds        PublishBuildsCmd        `cmd:"" help:"Manage uploaded builds"`
 	BetaGroups    PublishBetaGroupsCmd    `cmd:"" help:"Beta group management (ASC compatibility)"`
 	InternalShare PublishInternalShareCmd `cmd:"" help:"Upload artifacts for internal sharing"`
+}
+
+// PublishPlayCmd is a composed high-level ship job:
+// validate local inputs → upload binary → assign track release (status / fraction) → status.
+// Prefer --dry-run in CI preflight.
+type PublishPlayCmd struct {
+	File       string  `arg:"" help:"APK or AAB to publish" type:"existingfile"`
+	Track      string  `help:"Target track" default:"internal" enum:"internal,alpha,beta,production"`
+	Percentage float64 `help:"Staged rollout percentage (0-100). When >0, release status is inProgress with userFraction; 0 uses --status for a full track assignment"`
+	Status     string  `help:"Release status after upload (used when --percentage is 0)" default:"completed" enum:"draft,completed,halted,inProgress"`
+	DryRun     bool    `help:"Plan the publish job without network side effects"`
+}
+
+// Run executes the high-level publish play job.
+func (cmd *PublishPlayCmd) Run(globals *Globals) error {
+	if globals.Package == "" {
+		return errors.ErrPackageRequired
+	}
+	if !api.IsValidTrack(cmd.Track) {
+		return errors.ErrTrackInvalid
+	}
+
+	releaseStatus, userFraction, err := playship.ResolveReleaseParams(cmd.Status, cmd.Percentage)
+	if err != nil {
+		return err
+	}
+
+	// Local artifact readiness (no network, no nested CLI output).
+	for _, c := range validateArtifactFile(cmd.File) {
+		if c.Status == "fail" {
+			return errors.NewAPIError(errors.CodeValidationError, c.Message).
+				WithHint("Provide a non-empty .aab or .apk path")
+		}
+	}
+
+	plan := playship.BuildPlan(globals.Package, cmd.File, cmd.Track, cmd.Status, cmd.Percentage, userFraction)
+
+	if cmd.DryRun {
+		return outputResult(output.NewResult(map[string]interface{}{
+			"job":  "publish.play",
+			"mode": "dry-run",
+			"plan": plan,
+		}).WithNoOp("dry-run mode").WithServices("publish"), globals.Output, globals.Pretty)
+	}
+
+	// Live path: single edit → upload → Tracks.Update(status/fraction) → commit → status.
+	return cmd.runLivePublishPlay(globals, releaseStatus, userFraction)
+}
+
+// runLivePublishPlay performs upload + track assignment + commit in one edit.
+func (cmd *PublishPlayCmd) runLivePublishPlay(globals *Globals, releaseStatus string, userFraction float64) error {
+	ctx := globals.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	start := time.Now()
+	pkg := globals.Package
+
+	upload := &PublishUploadCmd{File: cmd.File, Track: cmd.Track, NoAutoCommit: true}
+	fileInfo, fileType, err := upload.validateUploadFile()
+	if err != nil {
+		return err
+	}
+
+	client, svc, err := upload.createUploadClient(ctx, globals)
+	if err != nil {
+		return err
+	}
+
+	editID, err := upload.getOrCreateEditID(ctx, client, svc, pkg)
+	if err != nil {
+		return err
+	}
+
+	versionCode, sha1, sha256, err := upload.uploadBinary(ctx, client, svc, pkg, editID, fileType)
+	if err != nil {
+		return err
+	}
+
+	if err := upload.uploadExpansionFiles(ctx, client, svc, pkg, editID, versionCode); err != nil {
+		return err
+	}
+
+	// Assign uploaded artifact to the track with the requested status / fraction.
+	trackPayload := playship.BuildTrackRelease(cmd.Track, releaseStatus, []int64{versionCode}, userFraction)
+	if err := client.Acquire(ctx); err != nil {
+		return err
+	}
+	updateErr := client.DoWithRetry(ctx, func() error {
+		_, uerr := svc.Edits.Tracks.Update(pkg, editID, cmd.Track, trackPayload).Context(ctx).Do()
+		return uerr
+	})
+	client.Release()
+	if updateErr != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("failed to assign version %d to track %s: %v", versionCode, cmd.Track, updateErr)).
+			WithHint("Upload succeeded in the edit but Tracks.Update failed; commit may be incomplete")
+	}
+
+	// Commit the edit (upload left NoAutoCommit so track assignment is included).
+	if err := client.Acquire(ctx); err != nil {
+		return err
+	}
+	commitErr := client.DoWithRetry(ctx, func() error {
+		_, cerr := svc.Edits.Commit(pkg, editID).Context(ctx).Do()
+		return cerr
+	})
+	client.Release()
+	if commitErr != nil {
+		return errors.NewAPIError(errors.CodeGeneralError,
+			fmt.Sprintf("failed to commit publish play edit: %v", commitErr)).
+			WithHint("Artifact may be uploaded; retry publish release or commit the edit manually")
+	}
+
+	result := output.NewResult(map[string]interface{}{
+		"job":           "publish.play",
+		"mode":          "live",
+		"package":       pkg,
+		"track":         cmd.Track,
+		"file":          cmd.File,
+		"fileType":      fileType,
+		"size":          fileInfo.Size(),
+		"versionCode":   versionCode,
+		"sha1":          sha1,
+		"sha256":        sha256,
+		"editId":        editID,
+		"committed":     true,
+		"status":        releaseStatus,
+		"userFraction":  userFraction,
+		"percentage":    cmd.Percentage,
+		"trackAssigned": true,
+	}).WithDuration(time.Since(start)).WithServices("publish", "androidpublisher")
+
+	if err := outputResult(result, globals.Output, globals.Pretty); err != nil {
+		return err
+	}
+
+	// Surface track status after commit.
+	return (&PublishStatusCmd{Track: cmd.Track}).Run(globals)
 }
 
 // PublishUploadCmd uploads APK or AAB.

--- a/internal/cli/kong_validate.go
+++ b/internal/cli/kong_validate.go
@@ -1,0 +1,448 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"google.golang.org/api/androidpublisher/v3"
+
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/api"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/errors"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/output"
+)
+
+// ValidateCmd is a high-level readiness report (ASC `validate` analogue).
+// It composes local checks and an optional dry-run plan for publish steps.
+// Network calls are skipped by default for safe CI preflight; pass --network
+// to run an opt-in package access probe (requires --package and credentials).
+type ValidateCmd struct {
+	Track   string `help:"Target track for the readiness plan" default:"internal" enum:"internal,alpha,beta,production"`
+	File    string `help:"Optional APK/AAB path to validate locally" type:"existingfile"`
+	Strict  bool   `help:"Treat warnings as failures"`
+	DryRun  bool   `help:"Plan checks without network side effects (default true)" default:"true"`
+	Network bool   `help:"Opt-in network probes: package access, track list, listing (requires --package and credentials)"`
+}
+
+// validatePackageAccessProbe is the network probe used by validate --network.
+// Defaults to probePackageAccess; tests may override.
+var validatePackageAccessProbe = probePackageAccess
+
+// validateTrackProbe lists tracks for a package (injectable for tests).
+var validateTrackProbe = defaultValidateTrackProbe
+
+// validateListingProbe checks default listing presence (injectable for tests).
+var validateListingProbe = defaultValidateListingProbe
+
+type readinessCheck struct {
+	Name           string `json:"name"`
+	Status         string `json:"status"` // pass, fail, warn, skip
+	Message        string `json:"message"`
+	Recommendation string `json:"recommendation,omitempty"`
+}
+
+// Run executes the validate command.
+func (cmd *ValidateCmd) Run(globals *Globals) error {
+	pkg := strings.TrimSpace(globals.Package)
+	checks := make([]readinessCheck, 0, 8)
+
+	// Package required for a real readiness report.
+	if pkg == "" {
+		checks = append(checks, readinessCheck{
+			Name:    "package",
+			Status:  "fail",
+			Message: "package name is required (--package)",
+		})
+	} else {
+		checks = append(checks, readinessCheck{
+			Name:    "package",
+			Status:  "pass",
+			Message: fmt.Sprintf("package=%s", pkg),
+		})
+	}
+
+	// Track validity
+	if !api.IsValidTrack(cmd.Track) {
+		checks = append(checks, readinessCheck{
+			Name:    "track",
+			Status:  "fail",
+			Message: fmt.Sprintf("invalid track %q", cmd.Track),
+		})
+	} else {
+		checks = append(checks, readinessCheck{
+			Name:    "track",
+			Status:  "pass",
+			Message: fmt.Sprintf("track=%s", cmd.Track),
+		})
+	}
+
+	// Optional artifact checks
+	if strings.TrimSpace(cmd.File) != "" {
+		checks = append(checks, validateArtifactFile(cmd.File)...)
+	} else {
+		checks = append(checks, readinessCheck{
+			Name:    "artifact",
+			Status:  "skip",
+			Message: "no --file provided; skipped local artifact checks",
+		})
+	}
+
+	// Profile / output contract notes (local)
+	profile := strings.TrimSpace(globals.Profile)
+	if profile == "" {
+		profile = "default"
+	}
+	checks = append(checks, readinessCheck{
+		Name:    "profile",
+		Status:  "pass",
+		Message: fmt.Sprintf("auth profile=%s", profile),
+	})
+	checks = append(checks, readinessCheck{
+		Name:    "output",
+		Status:  "pass",
+		Message: fmt.Sprintf("output=%s", globals.Output),
+	})
+
+	// Opt-in network probes. Default remains local-safe for CI without credentials.
+	checks = append(checks, cmd.runNetworkPackageAccessCheck(globals, pkg))
+	checks = append(checks, cmd.runNetworkTrackCheck(globals, pkg))
+	checks = append(checks, cmd.runNetworkListingCheck(globals, pkg))
+
+	// Planned publish steps (informational; no side effects from the plan itself)
+	plan := []string{
+		fmt.Sprintf("publish upload --package %s --track %s", pkgOrPlaceholder(pkg), cmd.Track),
+		fmt.Sprintf("publish status --package %s --track %s", pkgOrPlaceholder(pkg), cmd.Track),
+	}
+
+	passed, failed, warnings, skipped := 0, 0, 0, 0
+	for _, c := range checks {
+		switch c.Status {
+		case "pass":
+			passed++
+		case "fail":
+			failed++
+		case "warn":
+			warnings++
+		default:
+			skipped++
+		}
+	}
+
+	status := "ready"
+	if failed > 0 {
+		status = "not_ready"
+	} else if warnings > 0 && cmd.Strict {
+		status = "not_ready"
+	} else if warnings > 0 {
+		status = "ready_with_warnings"
+	}
+
+	data := map[string]interface{}{
+		"status":   status,
+		"package":  pkg,
+		"track":    cmd.Track,
+		"dryRun":   cmd.DryRun,
+		"network":  cmd.Network,
+		"strict":   cmd.Strict,
+		"checks":   checks,
+		"passed":   passed,
+		"failed":   failed,
+		"warnings": warnings,
+		"skipped":  skipped,
+		"plan":     plan,
+		"next": []string{
+			"gpd auth check --package <pkg>",
+			"gpd validate --package <pkg> --network",
+			"gpd publish play <app.aab> --package <pkg> --track <track> --dry-run",
+			"gpd publish play <app.aab> --package <pkg> --track <track>",
+		},
+	}
+
+	result := output.NewResult(data).WithServices("validate")
+	// No-op only when no network side effects occurred.
+	if cmd.DryRun && !cmd.Network {
+		result = result.WithNoOp("dry-run mode")
+	}
+
+	if err := outputResult(result, globals.Output, globals.Pretty); err != nil {
+		return err
+	}
+
+	if status == "not_ready" {
+		return errors.NewAPIError(errors.CodeValidationError, "readiness validation failed").
+			WithHint("Fix failing checks in the validate report").
+			WithDetails(map[string]interface{}{"failed": failed, "warnings": warnings})
+	}
+	return nil
+}
+
+// runNetworkPackageAccessCheck returns the network.package_access readiness check.
+// When --network is not set, the check is skipped (local-safe default).
+func (cmd *ValidateCmd) runNetworkPackageAccessCheck(globals *Globals, pkg string) readinessCheck {
+	const name = "network.package_access"
+
+	if !cmd.Network {
+		return readinessCheck{
+			Name:    name,
+			Status:  "skip",
+			Message: "network probes skipped (pass --network to enable; requires --package and credentials)",
+		}
+	}
+
+	if pkg == "" {
+		return readinessCheck{
+			Name:           name,
+			Status:         "fail",
+			Message:        "network probe requires --package",
+			Recommendation: "Pass --package com.example.app with --network",
+		}
+	}
+
+	ctx := authContext(globals)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := validatePackageAccessProbe(ctx, globals, pkg); err != nil {
+		return readinessCheck{
+			Name:   name,
+			Status: "fail",
+			Message: fmt.Sprintf(
+				"package access probe failed for %s: %v",
+				pkg, err,
+			),
+			Recommendation: "Configure credentials (`gpd auth login --key /path/to/sa.json` or ADC) and grant the service account Android Publisher access for this app in Play Console",
+		}
+	}
+
+	return readinessCheck{
+		Name:    name,
+		Status:  "pass",
+		Message: fmt.Sprintf("package access OK for %s (edits.insert+edits.delete)", pkg),
+	}
+}
+
+// runNetworkTrackCheck verifies the target track is visible via the Publisher API.
+func (cmd *ValidateCmd) runNetworkTrackCheck(globals *Globals, pkg string) readinessCheck {
+	const name = "network.track"
+	if !cmd.Network {
+		return readinessCheck{
+			Name:    name,
+			Status:  "skip",
+			Message: "network probes skipped (pass --network to enable)",
+		}
+	}
+	if pkg == "" {
+		return readinessCheck{
+			Name:           name,
+			Status:         "fail",
+			Message:        "track probe requires --package",
+			Recommendation: "Pass --package with --network",
+		}
+	}
+	ctx := authContext(globals)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tracks, err := validateTrackProbe(ctx, globals, pkg)
+	if err != nil {
+		return readinessCheck{
+			Name:           name,
+			Status:         "fail",
+			Message:        fmt.Sprintf("track list failed for %s: %v", pkg, err),
+			Recommendation: "Ensure credentials can list tracks (Android Publisher + app access)",
+		}
+	}
+	want := cmd.Track
+	found := false
+	for _, t := range tracks {
+		if t == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return readinessCheck{
+			Name:           name,
+			Status:         "fail",
+			Message:        fmt.Sprintf("track %q not found among %v", want, tracks),
+			Recommendation: "Use a valid track (internal/alpha/beta/production) or create the track in Play Console",
+		}
+	}
+	return readinessCheck{
+		Name:    name,
+		Status:  "pass",
+		Message: fmt.Sprintf("track %q present (listed %d tracks)", want, len(tracks)),
+	}
+}
+
+// runNetworkListingCheck verifies a default-locale listing can be read (warn if empty).
+func (cmd *ValidateCmd) runNetworkListingCheck(globals *Globals, pkg string) readinessCheck {
+	const name = "network.listing"
+	if !cmd.Network {
+		return readinessCheck{
+			Name:    name,
+			Status:  "skip",
+			Message: "network probes skipped (pass --network to enable)",
+		}
+	}
+	if pkg == "" {
+		return readinessCheck{
+			Name:           name,
+			Status:         "fail",
+			Message:        "listing probe requires --package",
+			Recommendation: "Pass --package with --network",
+		}
+	}
+	ctx := authContext(globals)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	title, err := validateListingProbe(ctx, globals, pkg)
+	if err != nil {
+		return readinessCheck{
+			Name:           name,
+			Status:         "warn",
+			Message:        fmt.Sprintf("listing probe failed for %s: %v", pkg, err),
+			Recommendation: "Ensure store listing exists for at least one locale, or ignore if app is not listed yet",
+		}
+	}
+	if strings.TrimSpace(title) == "" {
+		return readinessCheck{
+			Name:           name,
+			Status:         "warn",
+			Message:        "listing readable but title empty",
+			Recommendation: "Set listing title via gpd publish listing update",
+		}
+	}
+	return readinessCheck{
+		Name:    name,
+		Status:  "pass",
+		Message: fmt.Sprintf("listing OK (title=%q)", title),
+	}
+}
+
+func defaultValidateTrackProbe(ctx context.Context, globals *Globals, pkg string) ([]string, error) {
+	client, err := createAPIClient(ctx, globals)
+	if err != nil {
+		return nil, err
+	}
+	svc, err := client.AndroidPublisher()
+	if err != nil {
+		return nil, err
+	}
+	// Disposable edit to list tracks (Play requires an edit for track list).
+	edit, err := svc.Edits.Insert(pkg, &androidpublisher.AppEdit{}).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = svc.Edits.Delete(pkg, edit.Id).Context(ctx).Do()
+	}()
+	resp, err := svc.Edits.Tracks.List(pkg, edit.Id).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(resp.Tracks))
+	for _, t := range resp.Tracks {
+		if t != nil && t.Track != "" {
+			out = append(out, t.Track)
+		}
+	}
+	return out, nil
+}
+
+func defaultValidateListingProbe(ctx context.Context, globals *Globals, pkg string) (string, error) {
+	client, err := createAPIClient(ctx, globals)
+	if err != nil {
+		return "", err
+	}
+	svc, err := client.AndroidPublisher()
+	if err != nil {
+		return "", err
+	}
+	edit, err := svc.Edits.Insert(pkg, &androidpublisher.AppEdit{}).Context(ctx).Do()
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = svc.Edits.Delete(pkg, edit.Id).Context(ctx).Do()
+	}()
+	// Prefer en-US; fall back to first listing if present.
+	listing, err := svc.Edits.Listings.Get(pkg, edit.Id, "en-US").Context(ctx).Do()
+	if err == nil && listing != nil {
+		return listing.Title, nil
+	}
+	list, lerr := svc.Edits.Listings.List(pkg, edit.Id).Context(ctx).Do()
+	if lerr != nil {
+		return "", err
+	}
+	if list == nil || len(list.Listings) == 0 {
+		return "", fmt.Errorf("no store listings found")
+	}
+	return list.Listings[0].Title, nil
+}
+
+func pkgOrPlaceholder(pkg string) string {
+	if pkg == "" {
+		return "<package>"
+	}
+	return pkg
+}
+
+func validateArtifactFile(path string) []readinessCheck {
+	out := make([]readinessCheck, 0, 3)
+	info, err := os.Stat(path)
+	if err != nil {
+		return []readinessCheck{{
+			Name:    "artifact.exists",
+			Status:  "fail",
+			Message: fmt.Sprintf("cannot stat file: %v", err),
+		}}
+	}
+	if info.IsDir() {
+		return []readinessCheck{{
+			Name:    "artifact.exists",
+			Status:  "fail",
+			Message: "path is a directory, expected APK/AAB file",
+		}}
+	}
+	out = append(out, readinessCheck{
+		Name:    "artifact.exists",
+		Status:  "pass",
+		Message: fmt.Sprintf("file=%s size=%d", path, info.Size()),
+	})
+
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".aab", ".apk":
+		out = append(out, readinessCheck{
+			Name:    "artifact.type",
+			Status:  "pass",
+			Message: fmt.Sprintf("type=%s", strings.TrimPrefix(ext, ".")),
+		})
+	default:
+		out = append(out, readinessCheck{
+			Name:    "artifact.type",
+			Status:  "fail",
+			Message: fmt.Sprintf("unsupported extension %q (want .aab or .apk)", ext),
+		})
+	}
+
+	if info.Size() == 0 {
+		out = append(out, readinessCheck{
+			Name:    "artifact.size",
+			Status:  "fail",
+			Message: "file is empty",
+		})
+	} else {
+		out = append(out, readinessCheck{
+			Name:    "artifact.size",
+			Status:  "pass",
+			Message: fmt.Sprintf("%d bytes", info.Size()),
+		})
+	}
+	return out
+}

--- a/internal/cli/kong_validate_test.go
+++ b/internal/cli/kong_validate_test.go
@@ -1,0 +1,541 @@
+//go:build unit
+// +build unit
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/cli/playship"
+)
+
+func TestValidateCmd_DryRun_NoPackage(t *testing.T) {
+	cmd := &ValidateCmd{Track: "internal", DryRun: true}
+	globals := &Globals{Output: "json", Pretty: false}
+	err := cmd.Run(globals)
+	if err == nil {
+		t.Fatal("expected validation error without package")
+	}
+}
+
+func TestValidateCmd_DryRun_WithPackage(t *testing.T) {
+	cmd := &ValidateCmd{Track: "internal", DryRun: true}
+	globals := &Globals{Output: "json", Package: "com.example.app", Profile: "default"}
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCmd_DryRun_WithArtifact(t *testing.T) {
+	dir := t.TempDir()
+	aab := filepath.Join(dir, "app.aab")
+	if err := os.WriteFile(aab, []byte("fake-aab-bytes"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &ValidateCmd{Track: "production", File: aab, DryRun: true}
+	globals := &Globals{Output: "json", Package: "com.example.app"}
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCmd_DryRun_BadArtifactExt(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "app.txt")
+	if err := os.WriteFile(bad, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &ValidateCmd{Track: "internal", File: bad, DryRun: true}
+	globals := &Globals{Output: "json", Package: "com.example.app"}
+	err := cmd.Run(globals)
+	if err == nil {
+		t.Fatal("expected failure for bad artifact extension")
+	}
+	if !strings.Contains(err.Error(), "validation") && !strings.Contains(err.Error(), "readiness") {
+		// APIError message should mention validation/readiness
+		t.Logf("error: %v", err)
+	}
+}
+
+func TestValidateArtifactFile_Helpers(t *testing.T) {
+	dir := t.TempDir()
+	apk := filepath.Join(dir, "x.apk")
+	if err := os.WriteFile(apk, []byte("apk"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	checks := validateArtifactFile(apk)
+	if len(checks) < 2 {
+		t.Fatalf("expected checks, got %d", len(checks))
+	}
+	for _, c := range checks {
+		if c.Status == "fail" {
+			t.Fatalf("unexpected fail: %+v", c)
+		}
+	}
+}
+
+// TestValidateCmd_NetworkFlagOnStruct ensures --network is wired on ValidateCmd.
+func TestValidateCmd_NetworkFlagOnStruct(t *testing.T) {
+	typ := reflect.TypeOf(ValidateCmd{})
+	field, ok := typ.FieldByName("Network")
+	if !ok {
+		t.Fatal("ValidateCmd missing Network field for --network flag")
+	}
+	if field.Type.Kind() != reflect.Bool {
+		t.Fatalf("Network field type = %v, want bool", field.Type)
+	}
+	tag := field.Tag.Get("help")
+	if tag == "" {
+		t.Fatal("Network field should have a help tag for Kong CLI")
+	}
+	if !strings.Contains(strings.ToLower(tag), "network") {
+		t.Fatalf("Network help tag should mention network: %q", tag)
+	}
+}
+
+// TestValidateCmd_DefaultSkipsNetwork verifies local-safe default: without --network,
+// network.package_access is skipped and offline validation still succeeds.
+func TestValidateCmd_DefaultSkipsNetwork(t *testing.T) {
+	body := captureValidateStdout(t, func() error {
+		cmd := &ValidateCmd{Track: "internal", DryRun: true, Network: false}
+		globals := &Globals{Output: "json", Pretty: false, Package: "com.example.app"}
+		return cmd.Run(globals)
+	})
+
+	report := parseValidateJSON(t, body)
+	if network, _ := report["network"].(bool); network {
+		t.Fatalf("network flag in report = true, want false by default")
+	}
+	check := findValidateCheck(t, report, "network.package_access")
+	if check["status"] != "skip" {
+		t.Fatalf("network.package_access status = %v, want skip without --network", check["status"])
+	}
+	if report["status"] != "ready" {
+		t.Fatalf("status = %v, want ready for offline default", report["status"])
+	}
+}
+
+// TestValidateCmd_NetworkRequiresPackage fails clearly when --network lacks --package.
+func TestValidateCmd_NetworkRequiresPackage(t *testing.T) {
+	var ranProbe bool
+	prev := validatePackageAccessProbe
+	validatePackageAccessProbe = func(ctx context.Context, globals *Globals, pkg string) error {
+		ranProbe = true
+		return nil
+	}
+	t.Cleanup(func() { validatePackageAccessProbe = prev })
+
+	body := captureValidateStdout(t, func() error {
+		cmd := &ValidateCmd{Track: "internal", DryRun: true, Network: true}
+		globals := &Globals{Output: "json", Pretty: false}
+		return cmd.Run(globals)
+	})
+	if ranProbe {
+		t.Fatal("package access probe must not run when --package is empty")
+	}
+
+	report := parseValidateJSON(t, body)
+	check := findValidateCheck(t, report, "network.package_access")
+	if check["status"] != "fail" {
+		t.Fatalf("status = %v, want fail", check["status"])
+	}
+	msg, _ := check["message"].(string)
+	if !strings.Contains(msg, "--package") {
+		t.Fatalf("message should mention --package: %q", msg)
+	}
+	rec, _ := check["recommendation"].(string)
+	if rec == "" {
+		t.Fatal("expected recommendation when network probe lacks package")
+	}
+	if report["status"] != "not_ready" {
+		t.Fatalf("report status = %v, want not_ready", report["status"])
+	}
+}
+
+// TestValidateCmd_NetworkProbePass uses an injected probe success path.
+func TestValidateCmd_NetworkProbePass(t *testing.T) {
+	var sawPkg string
+	prevA, prevT, prevL := validatePackageAccessProbe, validateTrackProbe, validateListingProbe
+	validatePackageAccessProbe = func(ctx context.Context, globals *Globals, pkg string) error {
+		sawPkg = pkg
+		return nil
+	}
+	validateTrackProbe = func(ctx context.Context, g *Globals, pkg string) ([]string, error) {
+		return []string{"internal", "production"}, nil
+	}
+	validateListingProbe = func(ctx context.Context, g *Globals, pkg string) (string, error) {
+		return "Example", nil
+	}
+	t.Cleanup(func() {
+		validatePackageAccessProbe = prevA
+		validateTrackProbe = prevT
+		validateListingProbe = prevL
+	})
+
+	body := captureValidateStdout(t, func() error {
+		cmd := &ValidateCmd{Track: "internal", DryRun: true, Network: true}
+		globals := &Globals{Output: "json", Pretty: false, Package: "com.example.app"}
+		return cmd.Run(globals)
+	})
+	if sawPkg != "com.example.app" {
+		t.Fatalf("probe package = %q, want com.example.app", sawPkg)
+	}
+
+	report := parseValidateJSON(t, body)
+	if network, _ := report["network"].(bool); !network {
+		t.Fatal("report.network should be true when --network is set")
+	}
+	check := findValidateCheck(t, report, "network.package_access")
+	if check["status"] != "pass" {
+		t.Fatalf("status = %v, want pass", check["status"])
+	}
+	if report["status"] != "ready" {
+		t.Fatalf("report status = %v, want ready", report["status"])
+	}
+}
+
+// TestValidateCmd_NetworkProbeFailNoCredentials fails with a clear recommendation
+// when the probe reports credential/access failure (no panic).
+func TestValidateCmd_NetworkProbeFailNoCredentials(t *testing.T) {
+	prevA, prevT, prevL := validatePackageAccessProbe, validateTrackProbe, validateListingProbe
+	validatePackageAccessProbe = func(ctx context.Context, globals *Globals, pkg string) error {
+		return errors.New("no credentials configured")
+	}
+	validateTrackProbe = func(ctx context.Context, g *Globals, pkg string) ([]string, error) {
+		return nil, errors.New("no credentials configured")
+	}
+	validateListingProbe = func(ctx context.Context, g *Globals, pkg string) (string, error) {
+		return "", errors.New("no credentials configured")
+	}
+	t.Cleanup(func() {
+		validatePackageAccessProbe = prevA
+		validateTrackProbe = prevT
+		validateListingProbe = prevL
+	})
+
+	body := captureValidateStdout(t, func() error {
+		cmd := &ValidateCmd{Track: "internal", DryRun: true, Network: true}
+		globals := &Globals{Output: "json", Pretty: false, Package: "com.example.app"}
+		return cmd.Run(globals)
+	})
+
+	report := parseValidateJSON(t, body)
+	check := findValidateCheck(t, report, "network.package_access")
+	if check["status"] != "fail" {
+		t.Fatalf("status = %v, want fail", check["status"])
+	}
+	msg, _ := check["message"].(string)
+	if !strings.Contains(msg, "no credentials") && !strings.Contains(msg, "probe failed") {
+		t.Fatalf("message should describe probe failure: %q", msg)
+	}
+	rec, _ := check["recommendation"].(string)
+	if rec == "" || !strings.Contains(strings.ToLower(rec), "credential") {
+		t.Fatalf("recommendation should mention credentials: %q", rec)
+	}
+	if report["status"] != "not_ready" {
+		t.Fatalf("report status = %v, want not_ready", report["status"])
+	}
+}
+
+// TestValidateCmd_NetworkNotInvokedWithoutFlag ensures the probe is never called
+// unless --network is set (offline CI safety).
+func TestValidateCmd_NetworkNotInvokedWithoutFlag(t *testing.T) {
+	var called bool
+	prevA, prevT, prevL := validatePackageAccessProbe, validateTrackProbe, validateListingProbe
+	validatePackageAccessProbe = func(ctx context.Context, globals *Globals, pkg string) error {
+		called = true
+		return errors.New("should not be called")
+	}
+	validateTrackProbe = func(ctx context.Context, g *Globals, pkg string) ([]string, error) {
+		called = true
+		return nil, errors.New("should not be called")
+	}
+	validateListingProbe = func(ctx context.Context, g *Globals, pkg string) (string, error) {
+		called = true
+		return "", errors.New("should not be called")
+	}
+	t.Cleanup(func() {
+		validatePackageAccessProbe = prevA
+		validateTrackProbe = prevT
+		validateListingProbe = prevL
+	})
+
+	cmd := &ValidateCmd{Track: "internal", DryRun: true, Network: false}
+	globals := &Globals{Output: "json", Pretty: false, Package: "com.example.app"}
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("offline validate should succeed: %v", err)
+	}
+	if called {
+		t.Fatal("package access probe must not run without --network")
+	}
+}
+
+func captureValidateStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	runErr := fn()
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	// Network fail / missing package intentionally returns readiness error after printing.
+	_ = runErr
+	return string(out)
+}
+
+func parseValidateJSON(t *testing.T, body string) map[string]interface{} {
+	t.Helper()
+	// output.Result may wrap under "data"; accept either flat or nested.
+	var root map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &root); err != nil {
+		t.Fatalf("json unmarshal: %v\nbody: %s", err, body)
+	}
+	if data, ok := root["data"].(map[string]interface{}); ok {
+		return data
+	}
+	return root
+}
+
+func findValidateCheck(t *testing.T, report map[string]interface{}, name string) map[string]interface{} {
+	t.Helper()
+	raw, ok := report["checks"]
+	if !ok {
+		t.Fatalf("report missing checks: %#v", report)
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("checks type %T", raw)
+	}
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["name"] == name {
+			return m
+		}
+	}
+	t.Fatalf("check %q not found in %#v", name, list)
+	return nil
+}
+
+func TestPublishPlayCmd_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	aab := filepath.Join(dir, "app.aab")
+	if err := os.WriteFile(aab, []byte("fake"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &PublishPlayCmd{File: aab, Track: "internal", Status: "completed", DryRun: true}
+	globals := &Globals{Output: "json", Package: "com.example.app"}
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPublishPlayCmd_RequiresPackage(t *testing.T) {
+	dir := t.TempDir()
+	aab := filepath.Join(dir, "app.aab")
+	_ = os.WriteFile(aab, []byte("fake"), 0600)
+	cmd := &PublishPlayCmd{File: aab, Track: "internal", DryRun: true}
+	globals := &Globals{Output: "json"}
+	if err := cmd.Run(globals); err == nil {
+		t.Fatal("expected package required error")
+	}
+}
+
+func TestResolvePlayReleaseParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		pct        float64
+		wantStatus string
+		wantFrac   float64
+		wantErr    bool
+	}{
+		{name: "full completed", status: "completed", pct: 0, wantStatus: "completed", wantFrac: 0},
+		{name: "full draft", status: "draft", pct: 0, wantStatus: "draft", wantFrac: 0},
+		{name: "empty status defaults completed", status: "", pct: 0, wantStatus: "completed", wantFrac: 0},
+		{name: "staged 10 percent", status: "completed", pct: 10, wantStatus: "inProgress", wantFrac: 0.10},
+		{name: "staged 100 percent", status: "draft", pct: 100, wantStatus: "inProgress", wantFrac: 1.0},
+		{name: "invalid status", status: "nope", pct: 0, wantErr: true},
+		{name: "pct too high", status: "completed", pct: 101, wantErr: true},
+		{name: "pct negative", status: "completed", pct: -1, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatus, gotFrac, err := playship.ResolveReleaseParams(tt.status, tt.pct)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotStatus != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", gotStatus, tt.wantStatus)
+			}
+			if gotFrac != tt.wantFrac {
+				t.Fatalf("userFraction = %v, want %v", gotFrac, tt.wantFrac)
+			}
+		})
+	}
+}
+
+func TestBuildPlayTrackRelease_AppliesStatusAndFraction(t *testing.T) {
+	// Full release: completed, no fraction
+	track := playship.BuildTrackRelease("production", "completed", []int64{42}, 0)
+	if track.Track != "production" {
+		t.Fatalf("track = %q", track.Track)
+	}
+	if len(track.Releases) != 1 {
+		t.Fatalf("releases len = %d", len(track.Releases))
+	}
+	rel := track.Releases[0]
+	if rel.Status != "completed" {
+		t.Fatalf("status = %q, want completed (Status flag must apply)", rel.Status)
+	}
+	if rel.UserFraction != 0 {
+		t.Fatalf("userFraction = %v, want 0 for full release", rel.UserFraction)
+	}
+	if len(rel.VersionCodes) != 1 || rel.VersionCodes[0] != 42 {
+		t.Fatalf("versionCodes = %v, want [42]", rel.VersionCodes)
+	}
+
+	// Staged: inProgress + fraction
+	staged := playship.BuildTrackRelease("production", "inProgress", []int64{99}, 0.25)
+	srel := staged.Releases[0]
+	if srel.Status != "inProgress" {
+		t.Fatalf("staged status = %q, want inProgress", srel.Status)
+	}
+	if srel.UserFraction != 0.25 {
+		t.Fatalf("staged userFraction = %v, want 0.25", srel.UserFraction)
+	}
+}
+
+func TestBuildPublishPlayPlan_IncludesReleaseWithStatus(t *testing.T) {
+	plan := playship.BuildPlan("com.example.app", "app.aab", "internal", "draft", 0, 0)
+	if plan["releaseStatus"] != "draft" {
+		t.Fatalf("releaseStatus = %v, want draft from --status", plan["releaseStatus"])
+	}
+	steps, ok := plan["steps"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("steps type %T", plan["steps"])
+	}
+	var releaseStep map[string]interface{}
+	for _, s := range steps {
+		if s["action"] == "release" {
+			releaseStep = s
+			break
+		}
+	}
+	if releaseStep == nil {
+		t.Fatal("plan missing release step that assigns artifact to track")
+	}
+	if releaseStep["status"] != "draft" {
+		t.Fatalf("release step status = %v, want draft", releaseStep["status"])
+	}
+	if releaseStep["assignsArtifactToTrack"] != true {
+		t.Fatal("release step must assign artifact to track")
+	}
+
+	// Staged plan forces inProgress
+	stagedPlan := playship.BuildPlan("com.example.app", "app.aab", "production", "completed", 10, 0)
+	if stagedPlan["releaseStatus"] != "inProgress" {
+		t.Fatalf("staged releaseStatus = %v, want inProgress", stagedPlan["releaseStatus"])
+	}
+	if stagedPlan["userFraction"] != 0.10 {
+		t.Fatalf("staged userFraction = %v, want 0.10", stagedPlan["userFraction"])
+	}
+}
+
+func TestPublishPlayCmd_DryRunPlanReflectsStatus(t *testing.T) {
+	dir := t.TempDir()
+	aab := filepath.Join(dir, "app.aab")
+	if err := os.WriteFile(aab, []byte("fake"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout of dry-run to assert status appears in shipped output path.
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	cmd := &PublishPlayCmd{File: aab, Track: "beta", Status: "halted", DryRun: true}
+	globals := &Globals{Output: "json", Package: "com.example.app"}
+	runErr := cmd.Run(globals)
+	_ = w.Close()
+	os.Stdout = old
+	if runErr != nil {
+		t.Fatalf("run: %v", runErr)
+	}
+	out, _ := io.ReadAll(r)
+	body := string(out)
+	if !strings.Contains(body, `"status":"halted"`) && !strings.Contains(body, `"releaseStatus":"halted"`) {
+		t.Fatalf("dry-run output missing halted status: %s", body)
+	}
+	if !strings.Contains(body, `"action":"release"`) {
+		t.Fatalf("dry-run output missing release action: %s", body)
+	}
+}
+
+func TestValidateCmd_NetworkTrackAndListingInjected(t *testing.T) {
+	origAccess := validatePackageAccessProbe
+	origTrack := validateTrackProbe
+	origList := validateListingProbe
+	t.Cleanup(func() {
+		validatePackageAccessProbe = origAccess
+		validateTrackProbe = origTrack
+		validateListingProbe = origList
+	})
+	validatePackageAccessProbe = func(ctx context.Context, g *Globals, pkg string) error { return nil }
+	validateTrackProbe = func(ctx context.Context, g *Globals, pkg string) ([]string, error) {
+		return []string{"internal", "production"}, nil
+	}
+	validateListingProbe = func(ctx context.Context, g *Globals, pkg string) (string, error) {
+		return "My App", nil
+	}
+	cmd := &ValidateCmd{Track: "internal", DryRun: true, Network: true}
+	globals := &Globals{Output: "json", Package: "com.example.app"}
+	if err := cmd.Run(globals); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+}
+
+func TestValidateCmd_NetworkTrackMissing(t *testing.T) {
+	origAccess := validatePackageAccessProbe
+	origTrack := validateTrackProbe
+	origList := validateListingProbe
+	t.Cleanup(func() {
+		validatePackageAccessProbe = origAccess
+		validateTrackProbe = origTrack
+		validateListingProbe = origList
+	})
+	validatePackageAccessProbe = func(ctx context.Context, g *Globals, pkg string) error { return nil }
+	validateTrackProbe = func(ctx context.Context, g *Globals, pkg string) ([]string, error) {
+		return []string{"alpha"}, nil
+	}
+	validateListingProbe = func(ctx context.Context, g *Globals, pkg string) (string, error) {
+		return "T", nil
+	}
+	cmd := &ValidateCmd{Track: "production", DryRun: true, Network: true}
+	globals := &Globals{Output: "json", Package: "com.example.app"}
+	if err := cmd.Run(globals); err == nil {
+		t.Fatal("expected not_ready when track missing")
+	}
+}

--- a/internal/cli/outfmt/outfmt.go
+++ b/internal/cli/outfmt/outfmt.go
@@ -1,0 +1,89 @@
+// Package outfmt resolves the CLI's default --output format from flags, env, and TTY.
+//
+// This is a small domain package under internal/cli/ illustrating the preferred
+// layout for reusable CLI helpers. New command families should live in
+// internal/cli/<domain>/ with registration remaining in kong_cli.go.
+package outfmt
+
+import (
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// EnvDefaultOutput is the environment variable that overrides auto output format.
+const EnvDefaultOutput = "GPD_DEFAULT_OUTPUT"
+
+// validOutputFormats are accepted --output / GPD_DEFAULT_OUTPUT values.
+var validOutputFormats = map[string]bool{
+	"json":     true,
+	"table":    true,
+	"markdown": true,
+	"csv":      true,
+	"excel":    true,
+}
+
+// stdoutIsTerminal reports whether fd 1 is a terminal. Overridable in tests.
+var stdoutIsTerminal = func() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// ResolveDefaultOutput chooses the effective output format.
+//
+// Priority:
+//  1. explicitFlag — when the user passed --output on the command line
+//  2. envValue (GPD_DEFAULT_OUTPUT) when set to a valid format
+//  3. "table" when stdout is a TTY
+//  4. "json" otherwise (pipes, files, CI)
+//
+// explicitFlag is only honored when userSet is true so Kong's structural
+// default does not defeat TTY/env resolution.
+func ResolveDefaultOutput(explicitFlag string, userSet bool, isTTY bool, envValue string) string {
+	if userSet {
+		normalized := normalizeOutputFormat(explicitFlag)
+		if normalized != "" {
+			return normalized
+		}
+	}
+
+	if env := normalizeOutputFormat(envValue); env != "" {
+		return env
+	}
+
+	if isTTY {
+		return "table"
+	}
+	return "json"
+}
+
+// OutputFlagSet reports whether args include an explicit --output flag.
+func OutputFlagSet(args []string) bool {
+	for _, a := range args {
+		if a == "--output" {
+			return true
+		}
+		if strings.HasPrefix(a, "--output=") {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveOutputFromEnvAndTTY is the production helper used by RunKongCLI.
+func ResolveOutputFromEnvAndTTY(current string, args []string) string {
+	return ResolveDefaultOutput(
+		current,
+		OutputFlagSet(args),
+		stdoutIsTerminal(),
+		os.Getenv(EnvDefaultOutput),
+	)
+}
+
+func normalizeOutputFormat(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if validOutputFormats[v] {
+		return v
+	}
+	return ""
+}

--- a/internal/cli/outfmt/outfmt_test.go
+++ b/internal/cli/outfmt/outfmt_test.go
@@ -1,0 +1,188 @@
+//go:build unit
+// +build unit
+
+package outfmt
+
+import (
+	"testing"
+)
+
+func TestResolveDefaultOutput_PriorityChain(t *testing.T) {
+	tests := []struct {
+		name     string
+		explicit string
+		userSet  bool
+		isTTY    bool
+		env      string
+		want     string
+	}{
+		{
+			name:     "explicit json wins over tty table",
+			explicit: "json",
+			userSet:  true,
+			isTTY:    true,
+			env:      "table",
+			want:     "json",
+		},
+		{
+			name:     "explicit table wins over non-tty json",
+			explicit: "table",
+			userSet:  true,
+			isTTY:    false,
+			env:      "json",
+			want:     "table",
+		},
+		{
+			name:     "explicit markdown wins over env",
+			explicit: "markdown",
+			userSet:  true,
+			isTTY:    false,
+			env:      "csv",
+			want:     "markdown",
+		},
+		{
+			name:     "env wins when flag not set",
+			explicit: "json", // kong structural default, not user-set
+			userSet:  false,
+			isTTY:    true,
+			env:      "markdown",
+			want:     "markdown",
+		},
+		{
+			name:     "env csv when non-tty",
+			explicit: "",
+			userSet:  false,
+			isTTY:    false,
+			env:      "csv",
+			want:     "csv",
+		},
+		{
+			name:     "tty defaults to table",
+			explicit: "json",
+			userSet:  false,
+			isTTY:    true,
+			env:      "",
+			want:     "table",
+		},
+		{
+			name:     "non-tty defaults to json",
+			explicit: "json",
+			userSet:  false,
+			isTTY:    false,
+			env:      "",
+			want:     "json",
+		},
+		{
+			name:     "invalid env falls through to tty table",
+			explicit: "",
+			userSet:  false,
+			isTTY:    true,
+			env:      "yaml",
+			want:     "table",
+		},
+		{
+			name:     "invalid env falls through to non-tty json",
+			explicit: "",
+			userSet:  false,
+			isTTY:    false,
+			env:      "not-a-format",
+			want:     "json",
+		},
+		{
+			name:     "explicit empty with userSet falls through to env",
+			explicit: "",
+			userSet:  true,
+			isTTY:    false,
+			env:      "excel",
+			want:     "excel",
+		},
+		{
+			name:     "case insensitive explicit",
+			explicit: "TABLE",
+			userSet:  true,
+			isTTY:    false,
+			env:      "",
+			want:     "table",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveDefaultOutput(tt.explicit, tt.userSet, tt.isTTY, tt.env)
+			if got != tt.want {
+				t.Fatalf("ResolveDefaultOutput(%q, userSet=%v, tty=%v, env=%q) = %q, want %q",
+					tt.explicit, tt.userSet, tt.isTTY, tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutputFlagSet(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"empty", nil, false},
+		{"no output", []string{"auth", "status"}, false},
+		{"long flag", []string{"auth", "status", "--output", "json"}, true},
+		{"equals form", []string{"--output=table", "auth"}, true},
+		{"similar but not", []string{"--output-dir", "x"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OutputFlagSet(tt.args); got != tt.want {
+				t.Fatalf("OutputFlagSet(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveOutputFromEnvAndTTY_UsesEnv(t *testing.T) {
+	// Force non-TTY path for determinism, then set env.
+	origTTY := stdoutIsTerminal
+	stdoutIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdoutIsTerminal = origTTY })
+
+	t.Setenv(EnvDefaultOutput, "markdown")
+	got := ResolveOutputFromEnvAndTTY("json", []string{"version"})
+	if got != "markdown" {
+		t.Fatalf("got %q, want markdown from env", got)
+	}
+}
+
+func TestResolveOutputFromEnvAndTTY_ExplicitWins(t *testing.T) {
+	origTTY := stdoutIsTerminal
+	stdoutIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stdoutIsTerminal = origTTY })
+
+	t.Setenv(EnvDefaultOutput, "table")
+	got := ResolveOutputFromEnvAndTTY("json", []string{"--output", "json", "version"})
+	if got != "json" {
+		t.Fatalf("got %q, want json from explicit flag", got)
+	}
+}
+
+func TestResolveOutputFromEnvAndTTY_TTYDefault(t *testing.T) {
+	origTTY := stdoutIsTerminal
+	stdoutIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stdoutIsTerminal = origTTY })
+
+	t.Setenv(EnvDefaultOutput, "")
+	got := ResolveOutputFromEnvAndTTY("json", []string{"version"})
+	if got != "table" {
+		t.Fatalf("got %q, want table for TTY", got)
+	}
+}
+
+func TestResolveOutputFromEnvAndTTY_NonTTYDefault(t *testing.T) {
+	origTTY := stdoutIsTerminal
+	stdoutIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdoutIsTerminal = origTTY })
+
+	t.Setenv(EnvDefaultOutput, "")
+	got := ResolveOutputFromEnvAndTTY("json", []string{"version"})
+	if got != "json" {
+		t.Fatalf("got %q, want json for non-TTY", got)
+	}
+}

--- a/internal/cli/playship/playship.go
+++ b/internal/cli/playship/playship.go
@@ -1,0 +1,104 @@
+// Package playship holds pure helpers for high-level Play publish planning
+// (gpd publish play). Kong adapters live in package cli.
+package playship
+
+import (
+	"fmt"
+
+	"google.golang.org/api/androidpublisher/v3"
+
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/api"
+	"github.com/dl-alexandre/Google-Play-Developer-CLI/internal/errors"
+)
+
+// ResolveReleaseParams maps percentage + status into API release fields.
+// When percentage > 0, status is forced to inProgress and userFraction is percentage/100.
+// When percentage is 0, status is the requested status and userFraction is 0 (full track).
+func ResolveReleaseParams(status string, percentage float64) (releaseStatus string, userFraction float64, err error) {
+	if percentage < 0 || percentage > 100 {
+		return "", 0, errors.NewAPIError(errors.CodeValidationError,
+			fmt.Sprintf("invalid percentage: %g", percentage)).
+			WithHint("Percentage must be between 0 and 100")
+	}
+	if percentage > 0 {
+		if percentage < 0.01 {
+			return "", 0, errors.NewAPIError(errors.CodeValidationError,
+				fmt.Sprintf("invalid staged percentage: %g", percentage)).
+				WithHint("Staged rollout percentage must be at least 0.01")
+		}
+		return string(api.StatusInProgress), percentage / 100.0, nil
+	}
+	if status == "" {
+		status = string(api.StatusCompleted)
+	}
+	if !api.IsValidReleaseStatus(status) {
+		return "", 0, errors.NewAPIError(errors.CodeValidationError,
+			fmt.Sprintf("invalid release status: %s", status)).
+			WithHint("Valid statuses are: draft, completed, halted, inProgress")
+	}
+	return status, 0, nil
+}
+
+// BuildTrackRelease builds the Tracks.Update payload for publish play.
+func BuildTrackRelease(trackName, releaseStatus string, versionCodes []int64, userFraction float64) *androidpublisher.Track {
+	release := &androidpublisher.TrackRelease{
+		Status:       releaseStatus,
+		VersionCodes: versionCodes,
+	}
+	if userFraction > 0 {
+		release.UserFraction = userFraction
+	}
+	return &androidpublisher.Track{
+		Track:    trackName,
+		Releases: []*androidpublisher.TrackRelease{release},
+	}
+}
+
+// BuildPlan returns the operator-visible plan for dry-run and docs.
+func BuildPlan(pkg, file, track, status string, percentage, userFraction float64) map[string]interface{} {
+	releaseStatus, frac, _ := ResolveReleaseParams(status, percentage)
+	if releaseStatus == "" {
+		releaseStatus = status
+	}
+	if percentage > 0 {
+		userFraction = frac
+	}
+
+	steps := []map[string]interface{}{
+		{
+			"step":    1,
+			"action":  "validate",
+			"command": fmt.Sprintf("gpd validate --package %s --track %s --file %s --dry-run", pkg, track, file),
+		},
+		{
+			"step":    2,
+			"action":  "upload",
+			"command": fmt.Sprintf("gpd publish upload %s --package %s --track %s --no-auto-commit", file, pkg, track),
+		},
+		{
+			"step":                    3,
+			"action":                  "release",
+			"command":                 fmt.Sprintf("gpd publish release --package %s --track %s --status %s --version-codes <uploaded>", pkg, track, releaseStatus),
+			"status":                  releaseStatus,
+			"userFraction":            userFraction,
+			"track":                   track,
+			"assignsArtifactToTrack":  true,
+		},
+		{
+			"step":    4,
+			"action":  "status",
+			"command": fmt.Sprintf("gpd publish status --package %s --track %s", pkg, track),
+		},
+	}
+
+	return map[string]interface{}{
+		"package":       pkg,
+		"track":         track,
+		"file":          file,
+		"percentage":    percentage,
+		"status":        status,
+		"releaseStatus": releaseStatus,
+		"userFraction":  userFraction,
+		"steps":         steps,
+	}
+}

--- a/internal/cli/playship/playship_test.go
+++ b/internal/cli/playship/playship_test.go
@@ -1,0 +1,51 @@
+//go:build unit
+// +build unit
+
+package playship
+
+import "testing"
+
+func TestResolveReleaseParams(t *testing.T) {
+	st, frac, err := ResolveReleaseParams("draft", 0)
+	if err != nil || st != "draft" || frac != 0 {
+		t.Fatalf("draft: %s %v %v", st, frac, err)
+	}
+	st, frac, err = ResolveReleaseParams("completed", 10)
+	if err != nil || st != "inProgress" || frac != 0.1 {
+		t.Fatalf("staged: %s %v %v", st, frac, err)
+	}
+	if _, _, err := ResolveReleaseParams("nope", 0); err == nil {
+		t.Fatal("expected invalid status error")
+	}
+}
+
+func TestBuildTrackRelease(t *testing.T) {
+	tr := BuildTrackRelease("production", "completed", []int64{7}, 0)
+	if tr.Track != "production" || tr.Releases[0].Status != "completed" {
+		t.Fatalf("%+v", tr)
+	}
+	st := BuildTrackRelease("production", "inProgress", []int64{7}, 0.25)
+	if st.Releases[0].UserFraction != 0.25 {
+		t.Fatalf("fraction=%v", st.Releases[0].UserFraction)
+	}
+}
+
+func TestBuildPlan(t *testing.T) {
+	plan := BuildPlan("com.ex", "a.aab", "internal", "draft", 0, 0)
+	if plan["releaseStatus"] != "draft" {
+		t.Fatalf("%v", plan["releaseStatus"])
+	}
+	steps := plan["steps"].([]map[string]interface{})
+	found := false
+	for _, s := range steps {
+		if s["action"] == "release" {
+			found = true
+			if s["assignsArtifactToTrack"] != true {
+				t.Fatal("missing assign flag")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no release step")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -317,6 +317,7 @@ const (
 	EnvTimeout           = "GPD_TIMEOUT"
 	EnvStoreTokens       = "GPD_STORE_TOKENS" //nolint:gosec // G101: This is an env var name, not credentials
 	EnvCI                = "GPD_CI"
+	EnvDefaultOutput     = "GPD_DEFAULT_OUTPUT"
 )
 
 // GetEnvServiceAccountKey returns the service account key from environment.
@@ -339,6 +340,38 @@ func GetEnvPackage() string {
 
 func GetEnvAuthProfile() string {
 	return os.Getenv(EnvAuthProfile)
+}
+
+// ResolveAuthProfile picks the active auth profile.
+// Priority: explicit flag > GPD_AUTH_PROFILE > config activeProfile > "default".
+func ResolveAuthProfile(flagProfile string) string {
+	if strings.TrimSpace(flagProfile) != "" {
+		return strings.TrimSpace(flagProfile)
+	}
+	if env := strings.TrimSpace(GetEnvAuthProfile()); env != "" {
+		return env
+	}
+	if cfg, err := Load(); err == nil && cfg != nil {
+		if p := strings.TrimSpace(cfg.ActiveProfile); p != "" {
+			return p
+		}
+	}
+	return "default"
+}
+
+// SetActiveProfile persists the active auth profile to the config file.
+func SetActiveProfile(profile string) error {
+	profile = strings.TrimSpace(profile)
+	if profile == "" {
+		profile = "default"
+	}
+	cfg, loadWarn := Load()
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+	_ = loadWarn
+	cfg.ActiveProfile = profile
+	return cfg.Save()
 }
 
 // GetEnvTimeout returns the timeout from environment.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -587,3 +587,23 @@ func TestConfigValidate(t *testing.T) {
 		})
 	}
 }
+
+
+func TestResolveAuthProfile(t *testing.T) {
+	t.Setenv("GPD_AUTH_PROFILE", "")
+	// flag wins
+	if got := ResolveAuthProfile("from-flag"); got != "from-flag" {
+		t.Fatalf("flag: got %q", got)
+	}
+	t.Setenv("GPD_AUTH_PROFILE", "from-env")
+	if got := ResolveAuthProfile(""); got != "from-env" {
+		t.Fatalf("env: got %q", got)
+	}
+	t.Setenv("GPD_AUTH_PROFILE", "")
+	// without config active profile, default
+	home := setTestHome(t)
+	_ = home
+	if got := ResolveAuthProfile(""); got != "default" {
+		t.Fatalf("default: got %q", got)
+	}
+}

--- a/scripts/check-command-docs.sh
+++ b/scripts/check-command-docs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Fail if docs/COMMANDS.md is stale relative to live gpd help.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${GPD_BIN:-${ROOT}/bin/gpd}"
+DOC="${ROOT}/docs/COMMANDS.md"
+
+if [ ! -x "${BIN}" ]; then
+  (cd "${ROOT}" && make build)
+  BIN="${ROOT}/bin/gpd"
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "${TMP}"' EXIT
+
+GPD_BIN="${BIN}" bash "${ROOT}/scripts/generate-command-docs.sh" "${TMP}"
+
+# Compare taxonomy-relevant sections: ensure live top-level families appear in committed doc.
+HELP="$("${BIN}" --help 2>&1 || true)"
+for family in auth publish workflow validate; do
+  if ! echo "${HELP}" | grep -E "^  ${family}( |$)" >/dev/null 2>&1; then
+    # help may wrap differently — also accept anywhere as command token
+    if ! echo "${HELP}" | grep -w "${family}" >/dev/null 2>&1; then
+      echo "error: live help missing expected family: ${family}" >&2
+      exit 1
+    fi
+  fi
+  if ! grep -E "\`${family}\`| ${family} " "${DOC}" >/dev/null 2>&1 && ! grep -w "${family}" "${DOC}" >/dev/null 2>&1; then
+    echo "error: docs/COMMANDS.md missing family ${family}; run make generate-command-docs" >&2
+    exit 1
+  fi
+done
+
+# Auth subcommands present in live help must appear in doc.
+AUTH_HELP="$("${BIN}" auth --help 2>&1 || true)"
+for sub in status login logout list switch check doctor diagnose init; do
+  if echo "${AUTH_HELP}" | grep -E "auth ${sub}" >/dev/null 2>&1; then
+    if ! grep -E "auth ${sub}| ${sub}" "${DOC}" >/dev/null 2>&1; then
+      echo "error: docs/COMMANDS.md missing auth subcommand ${sub}" >&2
+      exit 1
+    fi
+  fi
+done
+
+# Must not invent absent auth subcommands that we know we do not have.
+# (Placeholder: keep list empty unless we intentionally remove commands.)
+
+# Drift: regenerated content should match committed file for the help bodies.
+# Compare ignoring the Generated: timestamp line.
+filter() { grep -v '^Generated:' "$1" | grep -v '^```$' ; }
+if ! diff -u <(filter "${DOC}") <(filter "${TMP}") >/dev/null 2>&1; then
+  echo "error: docs/COMMANDS.md is stale relative to live help." >&2
+  echo "Run: make generate-command-docs && git add docs/COMMANDS.md" >&2
+  diff -u <(filter "${DOC}") <(filter "${TMP}") | head -80 >&2 || true
+  exit 1
+fi
+
+echo "docs/COMMANDS.md is up to date with live help"

--- a/scripts/generate-command-docs.sh
+++ b/scripts/generate-command-docs.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Generate docs/COMMANDS.md from live gpd help output.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-${ROOT}/docs/COMMANDS.md}"
+BIN="${GPD_BIN:-${ROOT}/bin/gpd}"
+
+if [ ! -x "${BIN}" ]; then
+  echo "Building gpd..."
+  (cd "${ROOT}" && make build)
+  BIN="${ROOT}/bin/gpd"
+fi
+
+if [ ! -x "${BIN}" ]; then
+  echo "error: gpd binary not found at ${BIN}" >&2
+  exit 1
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "${TMP}"' EXIT
+
+{
+  echo "# Command Reference Guide"
+  echo
+  echo "This file is generated from live CLI help output."
+  echo "For authoritative command behavior, also use:"
+  echo
+  echo '```bash'
+  echo "gpd --help"
+  echo "gpd <command> --help"
+  echo "gpd <command> <subcommand> --help"
+  echo '```'
+  echo
+  echo "To regenerate:"
+  echo
+  echo '```bash'
+  echo "make generate-command-docs"
+  echo '```'
+  echo
+  echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo
+  echo "## Global help"
+  echo
+  echo '```'
+  "${BIN}" --help 2>&1 || true
+  echo '```'
+  echo
+  echo "## Auth"
+  echo
+  echo '```'
+  "${BIN}" auth --help 2>&1 || true
+  echo '```'
+  echo
+  echo "## Publish"
+  echo
+  echo '```'
+  "${BIN}" publish --help 2>&1 || true
+  echo '```'
+  echo
+  echo "## Validate"
+  echo
+  echo '```'
+  "${BIN}" validate --help 2>&1 || true
+  echo '```'
+  echo
+  echo "## Workflow"
+  echo
+  echo '```'
+  "${BIN}" workflow --help 2>&1 || true
+  echo '```'
+  echo
+  echo "## Command families (top-level)"
+  echo
+  # Extract top-level command names from help (lines like "  auth ...")
+  "${BIN}" --help 2>&1 | awk '
+    /^Commands:/ { in_cmds=1; next }
+    /^Flags:/ { in_cmds=0 }
+    /^Extension/ { in_cmds=0 }
+    in_cmds && /^  [a-z]/ {
+      # first token after indent
+      line=$0
+      sub(/^  /, "", line)
+      split(line, a, /[ \t]/)
+      name=a[1]
+      if (name != "" && name != "gpd") {
+        print "- `" name "`"
+      }
+    }
+  '
+  echo
+} >"${TMP}"
+
+mkdir -p "$(dirname "${OUT}")"
+mv "${TMP}" "${OUT}"
+echo "Wrote ${OUT}"

--- a/scripts/test-install-checksum.sh
+++ b/scripts/test-install-checksum.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Fixture tests for install.sh checksum verification and release asset naming.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRATCH="${1:-}"
+if [ -z "${SCRATCH}" ]; then
+  echo "usage: $0 <scratch-dir>" >&2
+  exit 2
+fi
+mkdir -p "${SCRATCH}"
+LOG="${SCRATCH}/install-verify.log"
+: >"${LOG}"
+
+log() { echo "$@" | tee -a "${LOG}"; }
+
+# shellcheck source=../install.sh
+GPD_INSTALL_LIB_ONLY=1 source "${ROOT}/install.sh"
+
+WORK="$(mktemp -d "${SCRATCH}/install-fixture.XXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+ASSET_NAME="gpd_test_asset.bin"
+ASSET_PATH="${WORK}/${ASSET_NAME}"
+echo "hello-gpd-install-fixture" >"${ASSET_PATH}"
+
+if command -v shasum >/dev/null 2>&1; then
+  GOOD_SUM="$(shasum -a 256 "${ASSET_PATH}" | awk '{print $1}')"
+else
+  GOOD_SUM="$(sha256sum "${ASSET_PATH}" | awk '{print $1}')"
+fi
+BAD_SUM="0000000000000000000000000000000000000000000000000000000000000000"
+
+GOOD_CHECKSUMS="${WORK}/checksums-good.txt"
+BAD_CHECKSUMS="${WORK}/checksums-bad.txt"
+# GoReleaser / shasum format: "<sha256>  <filename>" (two spaces)
+echo "${GOOD_SUM}  ${ASSET_NAME}" >"${GOOD_CHECKSUMS}"
+echo "${BAD_SUM}  ${ASSET_NAME}" >"${BAD_CHECKSUMS}"
+
+log "== match: verify_checksum should succeed =="
+if verify_checksum "${ASSET_PATH}" "${GOOD_CHECKSUMS}" "${ASSET_NAME}" >>"${LOG}" 2>&1; then
+  log "PASS: match verified"
+else
+  log "FAIL: expected match to succeed"
+  exit 1
+fi
+
+log "== mismatch: verify_checksum should fail (exit non-zero) =="
+set +e
+verify_checksum "${ASSET_PATH}" "${BAD_CHECKSUMS}" "${ASSET_NAME}" >>"${LOG}" 2>&1
+rc=$?
+set -e
+if [ "${rc}" -ne 0 ]; then
+  log "PASS: mismatch exited ${rc}"
+else
+  log "FAIL: expected mismatch to fail"
+  exit 1
+fi
+
+log "== end-to-end local install with good checksums =="
+INSTALL_DIR="${WORK}/bin"
+mkdir -p "${INSTALL_DIR}"
+GPD_INSTALL_ASSET="${ASSET_PATH}" \
+GPD_INSTALL_CHECKSUMS="${GOOD_CHECKSUMS}" \
+GPD_INSTALL_SKIP_EXTRACT=1 \
+GPD_INSTALL_SKIP_VERSION=1 \
+INSTALL_DIR="${INSTALL_DIR}" \
+  bash "${ROOT}/install.sh" >>"${LOG}" 2>&1
+if [ -x "${INSTALL_DIR}/gpd" ]; then
+  log "PASS: install placed binary at ${INSTALL_DIR}/gpd"
+else
+  log "FAIL: binary missing after install"
+  exit 1
+fi
+
+log "== end-to-end local install with bad checksums must fail =="
+INSTALL_DIR2="${WORK}/bin2"
+mkdir -p "${INSTALL_DIR2}"
+set +e
+GPD_INSTALL_ASSET="${ASSET_PATH}" \
+GPD_INSTALL_CHECKSUMS="${BAD_CHECKSUMS}" \
+GPD_INSTALL_SKIP_EXTRACT=1 \
+GPD_INSTALL_SKIP_VERSION=1 \
+INSTALL_DIR="${INSTALL_DIR2}" \
+  bash "${ROOT}/install.sh" >>"${LOG}" 2>&1
+rc=$?
+set -e
+if [ "${rc}" -ne 0 ]; then
+  log "PASS: bad checksum install exited ${rc}"
+else
+  log "FAIL: bad checksum install should not succeed"
+  exit 1
+fi
+# Ensure we did not leave a "verified" install of a bad asset as success path.
+if [ -f "${INSTALL_DIR2}/gpd" ]; then
+  # install may have partially run before verify — verify happens before mv when
+  # using GPD_INSTALL_ASSET path; binary should not be installed on mismatch.
+  log "NOTE: binary present after failed install (checking verify runs before install)"
+  # In our script verify runs before install; if file exists, fail.
+  log "FAIL: binary should not be installed after checksum mismatch"
+  exit 1
+else
+  log "PASS: no binary installed after mismatch"
+fi
+
+# ---------------------------------------------------------------------------
+# Release asset naming + checksum file format (matches .goreleaser.yml / install.sh)
+# ---------------------------------------------------------------------------
+log "== goreleaser config: SHA-256 + expected checksum asset name =="
+GORELEASER_YML="${ROOT}/.goreleaser.yml"
+if [ ! -f "${GORELEASER_YML}" ]; then
+  log "FAIL: missing ${GORELEASER_YML}"
+  exit 1
+fi
+
+if ! grep -qE 'algorithm:[[:space:]]*sha256' "${GORELEASER_YML}"; then
+  log "FAIL: .goreleaser.yml must set checksum.algorithm to sha256 (install.sh uses SHA-256)"
+  exit 1
+fi
+if ! grep -qE 'name_template:[[:space:]]*"gpd_\{\{ \.Version \}\}_checksums\.txt"' "${GORELEASER_YML}"; then
+  log "FAIL: .goreleaser.yml checksum name_template must be gpd_{{ .Version }}_checksums.txt"
+  exit 1
+fi
+if ! grep -q 'x86_64' "${GORELEASER_YML}"; then
+  log "FAIL: .goreleaser.yml archive name must map amd64 -> x86_64 for install.sh"
+  exit 1
+fi
+# Archive template must include ProjectName, Version, Os, Arch (with x86_64 branch)
+if ! grep -qE 'ProjectName.*Version.*Os' "${GORELEASER_YML}"; then
+  log "FAIL: .goreleaser.yml archive name_template must include ProjectName/Version/Os"
+  exit 1
+fi
+log "PASS: goreleaser checksum algorithm and naming aligned with install.sh"
+
+log "== simulated release checksums file (shasum format + archive names) =="
+VERSION="9.9.9"
+OS_LIST="darwin linux"
+ARCH_LIST="x86_64 arm64"
+CHECKSUMS_RELEASE="${WORK}/gpd_${VERSION}_checksums.txt"
+: >"${CHECKSUMS_RELEASE}"
+
+for os in ${OS_LIST}; do
+  for arch in ${ARCH_LIST}; do
+    fname="gpd_${VERSION}_${os}_${arch}.tar.gz"
+    fpath="${WORK}/${fname}"
+    # Fake archive payload (not a real tar; we only verify naming + checksum lines)
+    printf 'fake-archive-%s-%s\n' "${os}" "${arch}" >"${fpath}"
+    if command -v shasum >/dev/null 2>&1; then
+      sum="$(shasum -a 256 "${fpath}" | awk '{print $1}')"
+    else
+      sum="$(sha256sum "${fpath}" | awk '{print $1}')"
+    fi
+    # Standard GoReleaser/shasum line: hash, two spaces, filename
+    printf '%s  %s\n' "${sum}" "${fname}" >>"${CHECKSUMS_RELEASE}"
+  done
+done
+
+# Validate file shape: 64-hex hash, two spaces, gpd_VERSION_OS_ARCH.tar.gz
+line_count=0
+while IFS= read -r line || [ -n "${line}" ]; do
+  line_count=$((line_count + 1))
+  if ! printf '%s\n' "${line}" | grep -qE '^[0-9a-f]{64}  gpd_[0-9]+\.[0-9]+\.[0-9]+_(darwin|linux)_(x86_64|arm64)\.tar\.gz$'; then
+    log "FAIL: bad checksum line format: ${line}"
+    exit 1
+  fi
+done <"${CHECKSUMS_RELEASE}"
+
+if [ "${line_count}" -ne 4 ]; then
+  log "FAIL: expected 4 darwin/linux archive lines, got ${line_count}"
+  exit 1
+fi
+log "PASS: checksum file has ${line_count} valid shasum lines"
+
+# install.sh FILENAME pattern must match one of those assets for current host mapping
+SAMPLE_ASSET="gpd_${VERSION}_darwin_arm64.tar.gz"
+if ! verify_checksum "${WORK}/${SAMPLE_ASSET}" "${CHECKSUMS_RELEASE}" "${SAMPLE_ASSET}" >>"${LOG}" 2>&1; then
+  log "FAIL: verify_checksum failed for release-style asset ${SAMPLE_ASSET}"
+  exit 1
+fi
+log "PASS: verify_checksum accepts gpd_\${VERSION}_\${OS}_\${ARCH}.tar.gz entry"
+
+# Also accept fallback name checksums.txt with same body
+cp "${CHECKSUMS_RELEASE}" "${WORK}/checksums.txt"
+if ! verify_checksum "${WORK}/${SAMPLE_ASSET}" "${WORK}/checksums.txt" "${SAMPLE_ASSET}" >>"${LOG}" 2>&1; then
+  log "FAIL: verify_checksum failed against fallback checksums.txt"
+  exit 1
+fi
+log "PASS: fallback checksums.txt format works"
+
+# Document expected URL names for operators (matches install.sh)
+log "Expected release assets (install.sh):"
+log "  archive:   gpd_\${VERSION}_\${OS}_\${ARCH}.tar.gz  (OS=darwin|linux, ARCH=x86_64|arm64)"
+log "  checksums: gpd_\${VERSION}_checksums.txt  (preferred) or checksums.txt"
+
+log "ALL INSTALL VERIFY CHECKS PASSED"
+exit 0

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,59 @@
+# gpd agent skills pack
+
+ASC-style skill packs for AI agents operating **gpd** (Google Play Developer CLI).
+
+Each skill is a directory with a `SKILL.md` (YAML frontmatter + operational guide). Flags and examples match live `gpd <cmd> --help` at packaging time — prefer re-checking help if your binary is newer.
+
+## Skills
+
+| Skill | Path | Use for |
+| --- | --- | --- |
+| **gpd-auth** | [`gpd-auth/SKILL.md`](gpd-auth/SKILL.md) | Service accounts, profiles (`list` / `switch` / `delete` / `logout --name`), `doctor`, `check` |
+| **gpd-release** | [`gpd-release/SKILL.md`](gpd-release/SKILL.md) | `validate`, `publish play`, upload/release/rollout/promote/halt/rollback |
+| **gpd-reviews-vitals** | [`gpd-reviews-vitals/SKILL.md`](gpd-reviews-vitals/SKILL.md) | `reviews list` / `reply`, `vitals crashes` / `anrs` / query |
+
+## Install / wire into an agent
+
+Keep it simple — no special installer required:
+
+1. **Point the agent at the skill directories** (repo checkout or copied tree):
+
+   ```text
+   skills/gpd-auth
+   skills/gpd-release
+   skills/gpd-reviews-vitals
+   ```
+
+2. **Copy into your agent’s skills root** if it only loads a fixed path (examples):
+
+   ```bash
+   # from the gpd repo root
+   cp -R skills/gpd-auth skills/gpd-release skills/gpd-reviews-vitals \
+     /path/to/your-agent/skills/
+   ```
+
+3. **Symlink** when you want updates to track the repo:
+
+   ```bash
+   ln -s "$(pwd)/skills/gpd-auth" /path/to/your-agent/skills/gpd-auth
+   ln -s "$(pwd)/skills/gpd-release" /path/to/your-agent/skills/gpd-release
+   ln -s "$(pwd)/skills/gpd-reviews-vitals" /path/to/your-agent/skills/gpd-reviews-vitals
+   ```
+
+If your toolchain supports a skills CLI (e.g. `npx skills` or vendor-specific import), point it at this `skills/` directory or at individual `gpd-*` folders — packaging is plain markdown + frontmatter.
+
+## Agent operating rules (all skills)
+
+- Prefer **`--output json`** (and avoid interactive assumptions).
+- Always pass **`--package`** for package-scoped commands.
+- Prefer **`--dry-run`** before mutating publish/reply/halt/rollback operations.
+- Do **not invent flags** — run `gpd <command> --help`.
+- Auth before write ops: see **gpd-auth**.
+
+## Related in-repo docs
+
+- Main README — [AI Agent Integration](../README.md#ai-agent-integration)
+- [docs/COMMANDS.md](../docs/COMMANDS.md) — generated full command reference
+- [docs/auth-parity-guide.md](../docs/auth-parity-guide.md)
+- [docs/examples/release-workflow.md](../docs/examples/release-workflow.md)
+- `gpd --help` on your installed binary

--- a/skills/gpd-auth/SKILL.md
+++ b/skills/gpd-auth/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: gpd-auth
+description: >-
+  Authenticate and manage gpd (Google Play Developer CLI) credentials —
+  service accounts, named profiles, auth doctor/check/status, list/switch/delete/logout.
+  Use when setting up CI keys, diagnosing invalid credentials, switching teams/apps,
+  or verifying package access before publish/reviews/vitals calls.
+---
+
+# gpd-auth
+
+Service-account and multi-profile authentication for **gpd**.
+
+## When to use
+
+- First-time setup or CI credential wiring
+- “Permission denied” / auth failures before API calls
+- Multiple service accounts (teams, apps, environments)
+- Verifying the active profile can reach a package
+- Clearing or deleting stored profiles
+
+Do **not** invent OAuth browser flows for automation. Prefer service accounts.
+
+## Safe defaults
+
+| Practice | Guidance |
+| --- | --- |
+| Output | Prefer `--output json` (default in pipes/CI). Use `--pretty` only for humans. |
+| Package | Always pass `--package <appId>` for `auth check` and for doctor network probes. |
+| CI storage | Use `--store-tokens never` (or env without secure storage) so keys are not written to keychain. |
+| Key material | Prefer `--key-path` / `GOOGLE_APPLICATION_CREDENTIALS` / `GPD_SERVICE_ACCOUNT_KEY` over interactive login. |
+| Destructive | Prefer `auth logout --name …` before `auth delete`; use `--force` only when deleting the active profile. |
+| Source of truth | Run `gpd auth <cmd> --help` if unsure; do not invent flags. |
+
+### Global flags (all commands)
+
+```
+-p, --package=STRING
+    --output="json"          # json|table|markdown|csv|excel
+    --pretty
+    --timeout=30s
+    --store-tokens="auto"    # auto|never|secure
+    --fields=STRING
+    --quiet
+-v, --verbose
+    --key-path=STRING        # service account key file
+    --profile=STRING         # profile for this invocation
+    --cache-dir=STRING       # $GPD_CACHE_DIR
+```
+
+### Profile resolution order
+
+1. `--profile`
+2. `GPD_AUTH_PROFILE`
+3. config `activeProfile`
+4. `default`
+
+### Useful env vars
+
+| Env | Role |
+| --- | --- |
+| `GPD_AUTH_PROFILE` | Profile override |
+| `GPD_SERVICE_ACCOUNT_KEY` | Inline JSON key |
+| `GOOGLE_APPLICATION_CREDENTIALS` | ADC key path |
+| `GPD_CLIENT_ID` / `GPD_CLIENT_SECRET` | Device-flow OAuth (optional) |
+
+## Commands (exact help surface)
+
+### Status / list / switch
+
+```bash
+# Check whether credentials load and look valid
+gpd auth status --output json
+
+# List stored profiles (active marker in output)
+gpd auth list --output json
+
+# Make a profile active for subsequent commands
+gpd auth switch <profile> --output json
+
+# One-off profile without switching active
+gpd --profile team-b auth status --output json
+```
+
+### Login / init (service account)
+
+`auth init` is an alias of `auth login`.
+
+```bash
+# Store credentials under a named profile
+gpd auth login ci --key ./sa.json --output json
+# equivalent:
+gpd auth login ci --key-path ./sa.json --output json
+
+gpd auth init ci --key ./sa.json --output json
+
+# CI: authenticate without persisting tokens to secure storage
+gpd auth login ci --key ./sa.json --store-tokens never --output json
+
+# Device-flow OAuth only when client ID/secret are configured (not preferred for CI)
+gpd auth login ops --output json
+```
+
+Command-specific flags on login/init:
+
+| Flag | Meaning |
+| --- | --- |
+| `--key` | Path to service account key file (command-local; `--key-path` also works globally) |
+
+### Package permission check
+
+Requires global `--package`.
+
+```bash
+gpd auth check --package com.example.app --output json
+gpd --profile ci auth check --package com.example.app --output json
+```
+
+### Doctor / diagnose
+
+`auth diagnose` is an alias of `auth doctor`.
+
+```bash
+# Local diagnostics (no network probe)
+gpd auth doctor --output json
+
+# Attempt credential/token load refresh path
+gpd auth doctor --refresh-check --output json
+
+# Network package probe (requires --package + credentials)
+gpd auth doctor --refresh-check --network --package com.example.app --output json
+
+gpd auth diagnose --refresh-check --output json
+```
+
+Command-specific flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--refresh-check` | Attempt token refresh / credential load |
+| `--network` | Lightweight network permission probe (requires `--package`) |
+
+Also available (config-level): `gpd config doctor` — prefer **auth doctor** for credential health.
+
+### Logout / delete
+
+```bash
+# Sign out active profile
+gpd auth logout --output json
+
+# Sign out a named profile
+gpd auth logout --name ci --output json
+
+# Sign out all profiles
+gpd auth logout --all --output json
+
+# Delete a stored profile (refuses active unless --force)
+gpd auth delete staging --output json
+gpd auth delete staging --force --output json
+```
+
+| Command | Notable flags / args |
+| --- | --- |
+| `auth logout` | `--name=STRING` (default: active), `--all` |
+| `auth delete <profile>` | `--force` (allow deleting active; switches to `default`) |
+
+## Recommended agent workflow
+
+1. `gpd auth status --output json` — is anything loaded?
+2. If empty / broken: `gpd auth login <profile> --key ./sa.json --output json`
+3. Multi-account: `gpd auth list` → `gpd auth switch <profile>` (or `--profile` per call)
+4. Before write ops: `gpd auth check --package com.example.app --output json`
+5. On mystery failures: `gpd auth doctor --refresh-check --network --package com.example.app --output json`
+6. Cleanup: `gpd auth logout --name <profile>` or `gpd auth delete <profile>`
+
+## Exit codes (shared)
+
+`0` success · `1` API · `2` Auth · `3` Permission · `4` Validation · `5` Rate limit · `6` Network · `7` Not found · `8` Conflict
+
+## Related skills
+
+- **gpd-release** — validate / upload / publish play / rollout after auth works
+- **gpd-reviews-vitals** — reviews and Android vitals queries
+
+## Notes
+
+- Prefer live `gpd auth --help` / `gpd auth <cmd> --help` over memorized flags.
+- Play Console must grant the service account access to the app; API enablement alone is not enough.
+- For broader operator docs see `docs/auth-parity-guide.md` in the gpd repo.

--- a/skills/gpd-release/SKILL.md
+++ b/skills/gpd-release/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: gpd-release
+description: >-
+  Upload, validate, publish, promote, and stage rollouts for Google Play apps
+  with gpd (Google Play Developer CLI). Use for release pipelines: validate
+  readiness, publish play one-shot jobs, track status, staged rollouts, promote
+  between tracks, halt/rollback. Prefer --dry-run before mutating production.
+---
+
+# gpd-release
+
+End-to-end **Play release** workflows with **gpd**: validate → upload/assign track → status → rollout/promote/halt.
+
+## When to use
+
+- Shipping an APK/AAB to a track (`internal`, `alpha`, `beta`, `production`, or custom)
+- Pre-publish readiness checks (`gpd validate`)
+- One-shot “upload → track → status” jobs (`gpd publish play`)
+- Staged rollouts, promotions, halt, or rollback
+- CI/CD release steps that must stay non-interactive and JSON-parseable
+
+For credentials first, use the **gpd-auth** skill.
+
+## Safe defaults
+
+| Practice | Guidance |
+| --- | --- |
+| Package | Always pass `-p` / `--package <applicationId>`. |
+| Output | Prefer `--output json` (default in pipes/CI). Add `--pretty` only for humans. |
+| Dry-run | Run mutating commands with `--dry-run` first (especially production). |
+| Track | Start on `internal` / closed testing; promote later. |
+| Production | Prefer staged `--percentage` before full release; use `--confirm` on halt/rollback. |
+| Auth | Service account with Play access; see **gpd-auth**. |
+| Source of truth | Prefer `gpd <cmd> --help` over memorized flags. Do not invent flags. |
+
+### Global flags (all commands)
+
+```
+-p, --package=STRING
+    --output="json"          # json|table|markdown|csv|excel
+    --pretty
+    --timeout=30s
+    --store-tokens="auto"    # auto|never|secure
+    --fields=STRING
+    --quiet
+-v, --verbose
+    --key-path=STRING
+    --profile=STRING
+    --cache-dir=STRING       # $GPD_CACHE_DIR
+```
+
+## 1. Validate (pre-publish)
+
+```bash
+# Local / plan-only readiness (dry-run defaults to true)
+gpd validate --package com.example.app --track internal --output json
+
+# Include optional local artifact checks
+gpd validate --package com.example.app --file ./app-release.aab --track internal --output json
+
+# Treat warnings as failures
+gpd validate --package com.example.app --track production --strict --output json
+
+# Opt-in network package-access probe (needs credentials + --package)
+gpd validate --package com.example.app --network --output json
+
+# Explicit dry-run (default true) — plan without network side effects
+gpd validate --package com.example.app --dry-run --output json
+```
+
+| Flag | Notes |
+| --- | --- |
+| `--track` | Default `internal` |
+| `--file` | Optional APK/AAB path for local checks |
+| `--strict` | Warnings → failures |
+| `--dry-run` | Plan checks without network side effects (**default true**) |
+| `--network` | Opt-in package access probe (requires `--package` + credentials) |
+
+## 2. One-shot publish job (`publish play`)
+
+High-level **upload → track → status** (ASC-style publish analogue).
+
+```bash
+# Plan only
+gpd publish play ./app-release.aab \
+  --package com.example.app \
+  --track internal \
+  --dry-run \
+  --output json
+
+# Upload to internal, completed assignment
+gpd publish play ./app-release.aab \
+  --package com.example.app \
+  --track internal \
+  --status completed \
+  --output json
+
+# Staged production rollout at 10%
+gpd publish play ./app-release.aab \
+  --package com.example.app \
+  --track production \
+  --percentage 10 \
+  --output json
+```
+
+| Flag | Notes |
+| --- | --- |
+| `--track` | Default `internal` |
+| `--percentage` | `0–100`. When `>0`, release is `inProgress` with userFraction; `0` uses `--status` |
+| `--status` | Default `completed` (used when `--percentage` is `0`) |
+| `--dry-run` | Plan without network side effects |
+
+## 3. Granular publish steps
+
+### Upload
+
+```bash
+gpd publish upload ./app-release.aab \
+  --package com.example.app \
+  --track internal \
+  --dry-run \
+  --output json
+
+gpd publish upload ./app-release.aab \
+  --package com.example.app \
+  --track internal \
+  --output json
+```
+
+Notable flags: `--track` (default `internal`), `--edit-id`, `--obb-main`, `--obb-patch`, `--obb-main-ref-version`, `--obb-patch-ref-version`, `--no-auto-commit`, `--in-progress-review-behaviour`, `--dry-run`.
+
+### Create / update release
+
+```bash
+gpd publish release \
+  --package com.example.app \
+  --track internal \
+  --status draft \
+  --version-codes 123 \
+  --dry-run \
+  --output json
+
+gpd publish release \
+  --package com.example.app \
+  --track production \
+  --status inProgress \
+  --version-codes 123 \
+  --name "1.2.3" \
+  --release-notes-file ./release-notes.json \
+  --output json
+```
+
+Notable flags: `--track` (default `internal`), `--name`, `--status` (default `draft`), `--version-codes` (repeatable), `--retain-version-codes`, `--in-app-update-priority`, `--release-notes-file`, `--edit-id`, `--no-auto-commit`, `--in-progress-review-behaviour`, `--dry-run`, `--wait`, `--wait-timeout` (default `30m`).
+
+> Use **`--version-codes`** (plural) on `publish release`. Do not invent `--version-code` for this command.
+
+### Status & tracks
+
+```bash
+gpd publish tracks --package com.example.app --output json
+gpd publish status --package com.example.app --output json
+gpd publish status --package com.example.app --track production --output json
+```
+
+### Staged rollout
+
+```bash
+gpd publish rollout \
+  --package com.example.app \
+  --track production \
+  --percentage 10 \
+  --dry-run \
+  --output json
+
+gpd publish rollout \
+  --package com.example.app \
+  --track production \
+  --percentage 50 \
+  --output json
+```
+
+Notable flags: `--track` (default `production`), `--percentage` (`0.01–100.00`), `--edit-id`, `--no-auto-commit`, `--dry-run`.
+
+### Promote between tracks
+
+```bash
+gpd publish promote \
+  --package com.example.app \
+  --from-track internal \
+  --to-track production \
+  --percentage 10 \
+  --dry-run \
+  --output json
+
+gpd publish promote \
+  --package com.example.app \
+  --from-track beta \
+  --to-track production \
+  --output json
+```
+
+Notable flags: `--from-track`, `--to-track`, `--percentage` (default `0`), `--edit-id`, `--no-auto-commit`, `--dry-run`.
+
+### Halt / rollback (destructive)
+
+```bash
+# Halt in-progress production rollout
+gpd publish halt \
+  --package com.example.app \
+  --track production \
+  --dry-run \
+  --output json
+
+gpd publish halt \
+  --package com.example.app \
+  --track production \
+  --confirm \
+  --output json
+
+# Roll back to a prior version code
+gpd publish rollback \
+  --package com.example.app \
+  --track production \
+  --version-code 122 \
+  --dry-run \
+  --output json
+
+gpd publish rollback \
+  --package com.example.app \
+  --track production \
+  --version-code 122 \
+  --confirm \
+  --output json
+```
+
+Halt/rollback require `--confirm` for the real mutating path; always dry-run first.
+
+## Recommended agent workflow
+
+1. **Auth** — `gpd auth status` / `gpd auth check --package …` (see **gpd-auth**).
+2. **Validate** — `gpd validate --package … --file ./app.aab --output json` (add `--network` when probing access).
+3. **Dry-run publish** — `gpd publish play ./app.aab --package … --track internal --dry-run --output json`.
+4. **Execute** — drop `--dry-run` for the intended track.
+5. **Verify** — `gpd publish status --package … --track … --output json`.
+6. **Widen** — `gpd publish rollout --percentage N` or `gpd publish promote …`.
+7. **Incident** — halt with `--confirm`, or rollback with `--version-code` + `--confirm`.
+
+## Exit codes (shared)
+
+`0` success · `1` API · `2` Auth · `3` Permission · `4` Validation · `5` Rate limit · `6` Network · `7` Not found · `8` Conflict
+
+## Related skills
+
+- **gpd-auth** — service accounts, profiles, doctor/check
+- **gpd-reviews-vitals** — post-release review replies and crash/ANR vitals
+
+## Notes
+
+- Prefer live `gpd publish --help` / `gpd validate --help` when flags change.
+- JSON envelope shape: `{ "data": …, "error": …, "meta": … }`.

--- a/skills/gpd-reviews-vitals/SKILL.md
+++ b/skills/gpd-reviews-vitals/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: gpd-reviews-vitals
+description: >-
+  List/reply to Google Play user reviews and query Android Vitals (crashes, ANRs,
+  error issues/reports, metrics) via gpd. Use for support triage, review response
+  automation, and post-release stability monitoring. Always pass --package and
+  prefer JSON output; dry-run replies before sending.
+---
+
+# gpd-reviews-vitals
+
+**Reviews** and **Android Vitals** operations with **gpd**.
+
+## When to use
+
+- Listing or filtering user reviews (rating, language, date)
+- Drafting / sending developer replies (single or batched)
+- Checking crash rate, ANR rate, or other vitals after a release
+- Searching error issues/reports or listing anomalies
+- Support / quality triage agents that need structured JSON
+
+Auth first with **gpd-auth**. For shipping builds use **gpd-release**.
+
+## Safe defaults
+
+| Practice | Guidance |
+| --- | --- |
+| Package | Always pass `-p` / `--package <applicationId>`. |
+| Output | Prefer `--output json` (default in pipes/CI). Use `--pretty` for humans. |
+| Replies | Always `--dry-run` before live `reviews reply`; respect `--max-actions` / `--rate-limit`. |
+| Scope | Start with small `--page-size` / date windows; use `--all` only when needed. |
+| PII | Review text may contain personal data — avoid logging full payloads in shared traces. |
+| Source of truth | Prefer `gpd reviews --help` / `gpd vitals --help`. Do not invent flags. |
+
+### Global flags (all commands)
+
+```
+-p, --package=STRING
+    --output="json"          # json|table|markdown|csv|excel
+    --pretty
+    --timeout=30s
+    --store-tokens="auto"    # auto|never|secure
+    --fields=STRING
+    --quiet
+-v, --verbose
+    --key-path=STRING
+    --profile=STRING
+    --cache-dir=STRING       # $GPD_CACHE_DIR
+```
+
+---
+
+## Reviews
+
+### List
+
+```bash
+# Recent / filtered reviews as JSON
+gpd reviews list \
+  --package com.example.app \
+  --min-rating 1 \
+  --max-rating 2 \
+  --page-size 50 \
+  --output json
+
+# Include body text and optional translation
+gpd reviews list \
+  --package com.example.app \
+  --include-review-text \
+  --translation-language en \
+  --language en \
+  --start-date 2026-01-01 \
+  --end-date 2026-01-31 \
+  --scan-limit 100 \
+  --output json --pretty
+
+# Paginate or fetch all pages
+gpd reviews list --package com.example.app --page-token TOKEN --output json
+gpd reviews list --package com.example.app --all --output json
+```
+
+| Flag | Notes |
+| --- | --- |
+| `--min-rating` / `--max-rating` | 1–5 |
+| `--language` | Filter by review language |
+| `--start-date` / `--end-date` | ISO 8601 |
+| `--scan-limit` | Default `100` |
+| `--include-review-text` | Include review body |
+| `--translation-language` | Translate reviews |
+| `--page-size` | Default `50` |
+| `--page-token` | Pagination |
+| `--all` | Fetch all pages |
+
+### Get one review
+
+```bash
+gpd reviews get REVIEW_ID \
+  --package com.example.app \
+  --include-review-text \
+  --output json
+```
+
+Optional: `--translation-language`.
+
+### Reply (mutating)
+
+```bash
+# Plan only
+gpd reviews reply REVIEW_ID \
+  --package com.example.app \
+  --text "Thanks for the feedback — we're looking into this." \
+  --dry-run \
+  --output json
+
+# Send reply
+gpd reviews reply REVIEW_ID \
+  --package com.example.app \
+  --text "Thanks for the feedback — we're looking into this." \
+  --output json
+
+# Template-driven / batch-friendly
+gpd reviews reply \
+  --package com.example.app \
+  --template-file ./reply.txt \
+  --max-actions 10 \
+  --rate-limit 5s \
+  --dry-run \
+  --output json
+```
+
+| Flag | Notes |
+| --- | --- |
+| `--text` | Reply body |
+| `--template-file` | Template file for reply |
+| `--max-actions` | Default `10` — max replies per execution |
+| `--rate-limit` | Default `5s` between replies |
+| `--dry-run` | Show intended actions without executing |
+
+### Response get / delete
+
+```bash
+gpd reviews response-get REVIEW_ID --package com.example.app --output json
+gpd reviews response-delete REVIEW_ID --package com.example.app --output json
+```
+
+`response-delete` is destructive; confirm intent with the operator before running.
+
+---
+
+## Vitals
+
+### Crashes & ANRs
+
+```bash
+gpd vitals crashes \
+  --package com.example.app \
+  --start-date 2026-01-01 \
+  --end-date 2026-01-31 \
+  --output json
+
+gpd vitals anrs \
+  --package com.example.app \
+  --start-date 2026-01-01 \
+  --end-date 2026-01-31 \
+  --output json
+
+# Optional grouping / pagination
+gpd vitals crashes \
+  --package com.example.app \
+  --dimensions apiLevel,versionCode \
+  --page-size 100 \
+  --output json
+```
+
+Shared flags for `crashes` / `anrs`:
+
+| Flag | Notes |
+| --- | --- |
+| `--start-date` / `--end-date` | ISO 8601 |
+| `--dimensions` | Repeatable grouping dimensions |
+| `--format` | `json` (default) or `csv` — command-local format |
+| `--page-size` | Default `100` |
+| `--page-token` | Pagination |
+| `--all` | Fetch all pages |
+
+> Prefer global `--output json` for the standard result envelope. Command `--format` is for vitals export shape (`json`/`csv`).
+
+### Generic vitals query
+
+```bash
+gpd vitals query \
+  --package com.example.app \
+  --metrics crashRate,anrRate \
+  --start-date 2026-01-01 \
+  --end-date 2026-01-31 \
+  --output json
+
+gpd vitals capabilities --output json
+```
+
+`vitals query` flags: `--start-date`, `--end-date`, `--metrics` (default includes `crashRate`), `--dimensions`, `--format`, `--page-size`, `--page-token`, `--all`.
+
+### Errors & other metrics (overview)
+
+```bash
+gpd vitals errors issues --package com.example.app --output json
+gpd vitals errors reports --package com.example.app --output json
+gpd vitals errors counts get --package com.example.app --output json
+gpd vitals errors counts query --package com.example.app --output json
+
+gpd vitals metrics excessive-wakeups --package com.example.app --output json
+gpd vitals metrics slow-rendering --package com.example.app --output json
+gpd vitals metrics slow-start --package com.example.app --output json
+gpd vitals metrics stuck-wakelocks --package com.example.app --output json
+
+gpd vitals anomalies list --package com.example.app --output json
+```
+
+Run `gpd vitals <cmd> --help` for command-specific filters before automating.
+
+---
+
+## Recommended agent workflows
+
+### Support triage
+
+1. `gpd reviews list --package … --min-rating 1 --max-rating 2 --include-review-text --output json`
+2. `gpd reviews get <id> --package … --include-review-text --output json`
+3. Draft reply → `gpd reviews reply <id> --package … --text "…" --dry-run --output json`
+4. On approval → same command without `--dry-run`
+
+### Post-release stability
+
+1. Confirm package auth (`gpd auth check --package …`).
+2. `gpd vitals crashes` / `gpd vitals anrs` for the rollout window.
+3. Optionally `gpd vitals query --metrics crashRate,anrRate …`.
+4. If rates spike, use **gpd-release** to halt/rollback.
+
+## Exit codes (shared)
+
+`0` success · `1` API · `2` Auth · `3` Permission · `4` Validation · `5` Rate limit · `6` Network · `7` Not found · `8` Conflict
+
+## Related skills
+
+- **gpd-auth** — credentials, profiles, doctor/check
+- **gpd-release** — validate / publish / rollout / halt
+
+## Notes
+
+- Prefer live `gpd reviews --help` and `gpd vitals --help`.
+- JSON envelope: `{ "data": …, "error": …, "meta": … }`.


### PR DESCRIPTION
## Summary
Delivers the ASC-style product/ops batch for gpd:

- **TTY-aware output** (`GPD_DEFAULT_OUTPUT`, table on TTY / json in pipes)
- **Auth multi-profile** complete surface: list/switch/init/delete/logout (`--name`/`--all`), doctor/check
- **`gpd validate`** readiness report + `--network` probes (package access, track list, listing)
- **`gpd publish play`** upload → Tracks.Update(status/fraction) → commit → status
- **Install trust**: SHA-256 checksums; GoReleaser archives named for `install.sh`
- **`setup-gpd`** composite GitHub Action
- **Agent skills** under `skills/gpd-*`
- Domain packages: `internal/cli/outfmt`, `internal/cli/playship`
- Generated `docs/COMMANDS.md` + `make check-docs`

## Test plan
- [x] `go test -tags=unit ./...`
- [x] `make test-install-checksum`
- [x] `make check-docs`
- [x] `goreleaser release --snapshot --clean --skip=publish` (archives + checksums named correctly)
- [ ] After merge: tag `v0.6.5` to publish production assets with new naming

## Notes
- CI docs pin `setup-gpd` binary to `v0.6.4` until the next release ships the new asset names.
- Production tag intentionally left for post-merge (avoids releasing from a pre-merge branch tip only).