### PR TITLE
ci: harden Dependabot automation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,6 +19,7 @@ jobs:
         uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-commit-verification: true
 
       - name: Enable patch auto-merge
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
@@ -35,4 +36,3 @@ jobs:
           esac
 
           gh pr merge "${PR_URL}" --auto --squash --delete-branch
-

--- a/.github/workflows/dependabot-failure-triage.yml
+++ b/.github/workflows/dependabot-failure-triage.yml
@@ -75,6 +75,7 @@ jobs:
 
               const failures = checks.filter((check) =>
                 check.status === 'completed' &&
+                !['Dependabot Safe Auto-Merge', 'Label and summarize failed Dependabot PRs'].includes(check.name) &&
                 ['failure', 'timed_out', 'cancelled', 'startup_failure'].includes(check.conclusion)
               );
 


### PR DESCRIPTION
Accept GitHub-generated Dependabot maintenance rebases after validating the PR actor, and ignore the optional auto-merge check during failure triage.