### PR TITLE
ci: fix Dependabot failure triage filter

### DIFF
--- a/.github/workflows/dependabot-failure-triage.yml
+++ b/.github/workflows/dependabot-failure-triage.yml
@@ -75,7 +75,7 @@ jobs:
 
               const failures = checks.filter((check) =>
                 check.status === 'completed' &&
-                !['Dependabot Safe Auto-Merge', 'Label and summarize failed Dependabot PRs'].includes(check.name) &&
+                !['Enable safe patch auto-merge', 'Dependabot Safe Auto-Merge', 'Label and summarize failed Dependabot PRs'].includes(check.name) &&
                 ['failure', 'timed_out', 'cancelled', 'startup_failure'].includes(check.conclusion)
               );
 


### PR DESCRIPTION
Ignore the optional auto-merge job by its actual check-run name so clean dependency updates are not mislabeled as manual fixes.